### PR TITLE
[codex] Add YouTube playlist blog posts

### DIFF
--- a/_posts/2025-05-29-culturafreak-001.md
+++ b/_posts/2025-05-29-culturafreak-001.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "CULTURAFREAK #001"
+date: 2025-05-29 09:00:00 -0400
+description: "¡Bienvenidos al primer episodio de CULTURAFREAK!"
+image: "https://img.youtube.com/vi/3bDyg1-vKsU/hqdefault.jpg"
+image_alt: "CULTURAFREAK #001"
+resumen: "¡Bienvenidos al primer episodio de CULTURAFREAK!"
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "3bDyg1-vKsU"
+youtube_url: "https://www.youtube.com/watch?v=3bDyg1-vKsU"
+---
+
+¡Bienvenidos al primer episodio de CULTURAFREAK!
+
+
+Arrancamos en fase beta con un repaso de las noticias más curiosas y relevantes del mundo tech y la cultura freak: el nuevo Xiaomi Mi 9, los plegables de Samsung, promesas de Elon Musk, rumores de Google en el mundo gamer, avances espaciales de la NASA y hasta un bug de WinRAR que vivió 14 años.
+
+
+Esto apenas empieza, y tú formas parte del experimento. 🚀
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/3bDyg1-vKsU" title="CULTURAFREAK #001" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-002.md
+++ b/_posts/2025-05-29-culturafreak-002.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #002"
+date: 2025-05-29 09:00:00 -0400
+description: "En esta segunda entrega repasamos el móvil más caro desde 1996 (sí, es de Samsung), cómo han cambiado las empresas más valiosas del mundo en dos décadas, el próximo gran..."
+image: "https://img.youtube.com/vi/9bPcuc_bdSc/hqdefault.jpg"
+image_alt: "CULTURAFREAK #002"
+resumen: "En esta segunda entrega repasamos el móvil más caro desde 1996 (sí, es de Samsung), cómo han cambiado las empresas más valiosas del mundo en dos décadas, el próximo gran..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "9bPcuc_bdSc"
+youtube_url: "https://www.youtube.com/watch?v=9bPcuc_bdSc"
+---
+
+En esta segunda entrega repasamos el móvil más caro desde 1996 (sí, es de Samsung), cómo han cambiado las empresas más valiosas del mundo en dos décadas, el próximo gran lanzamiento de SpaceX y… drones kamikaze made in Kalashnikov. Además, las zapatillas que se atan solas de Nike están fallando por culpa de Android y Newtral busca programadores para luchar contra las fake news con inteligencia artificial.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/9bPcuc_bdSc" title="CULTURAFREAK #002" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-003.md
+++ b/_posts/2025-05-29-culturafreak-003.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "CULTURAFREAK #003"
+date: 2025-05-29 09:00:00 -0400
+description: "Oscars, turismo espacial y el festival de móviles del MWC 2019."
+image: "https://img.youtube.com/vi/r9-XXImKTM8/hqdefault.jpg"
+image_alt: "CULTURAFREAK #003"
+resumen: "Oscars, turismo espacial y el festival de móviles del MWC 2019."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "r9-XXImKTM8"
+youtube_url: "https://www.youtube.com/watch?v=r9-XXImKTM8"
+---
+
+Oscars, turismo espacial y el festival de móviles del MWC 2019.
+
+
+En este episodio repasamos los ganadores de los premios de la Academia, el nuevo logro de Virgin Galactic, y una herramienta de Facebook tan potente como inquietante. Además, Huawei, Nokia, Xiaomi, LG y Microsoft sacan músculo con plegables, cámaras locas, móviles 5G y gafas de realidad aumentada. ¿Listos para el futuro?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/r9-XXImKTM8" title="CULTURAFREAK #003" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-004.md
+++ b/_posts/2025-05-29-culturafreak-004.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #004"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple calienta motores para presentar su plataforma de streaming, Spark permite delegar correos, y Dropbox recorta funciones a los usuarios gratuitos. Además: la wallet del..."
+image: "https://img.youtube.com/vi/Atc_zYvQ5UI/hqdefault.jpg"
+image_alt: "CULTURAFREAK #004"
+resumen: "Apple calienta motores para presentar su plataforma de streaming, Spark permite delegar correos, y Dropbox recorta funciones a los usuarios gratuitos. Además: la wallet del..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Atc_zYvQ5UI"
+youtube_url: "https://www.youtube.com/watch?v=Atc_zYvQ5UI"
+---
+
+Apple calienta motores para presentar su plataforma de streaming, Spark permite delegar correos, y Dropbox recorta funciones a los usuarios gratuitos. Además: la wallet del Galaxy S10 ignora Bitcoin, WhatsApp estrena búsqueda inversa de imágenes, y la NASA comparte la última panorámica de Opportunity. También hablamos de privacidad, con DuckDuckGo, anuncios personalizados en SmartTVs y… el bloqueo de ProtonMail en Rusia. Casi nada.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Atc_zYvQ5UI" title="CULTURAFREAK #004" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-005.md
+++ b/_posts/2025-05-29-culturafreak-005.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #005"
+date: 2025-05-29 09:00:00 -0400
+description: "Semana cargada: SpaceX clava el primer aterrizaje triple del Falcon Heavy, Israel se estrella (literalmente) en la Luna y Rusia presume de soldados con superpoderes entrenados..."
+image: "https://img.youtube.com/vi/0iLBnB3-AL4/hqdefault.jpg"
+image_alt: "CULTURAFREAK #005"
+resumen: "Semana cargada: SpaceX clava el primer aterrizaje triple del Falcon Heavy, Israel se estrella (literalmente) en la Luna y Rusia presume de soldados con superpoderes entrenados..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "0iLBnB3-AL4"
+youtube_url: "https://www.youtube.com/watch?v=0iLBnB3-AL4"
+---
+
+Semana cargada: SpaceX clava el primer aterrizaje triple del Falcon Heavy, Israel se estrella (literalmente) en la Luna y Rusia presume de soldados con superpoderes entrenados con delfines. Hablamos también del nuevo Disney+, la detención de Julian Assange, la caída de beneficios de Samsung, un nuevo Edge con alma de Chrome, y cómo Skype ahora te deja compartir pantalla desde el iPhone. Ah, y Amazon quiere unos AirPods… pero más baratos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/0iLBnB3-AL4" title="CULTURAFREAK #005" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-007.md
+++ b/_posts/2025-05-29-culturafreak-007.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "CULTURAFREAK #007"
+date: 2025-05-29 09:00:00 -0400
+description: "Huawei vs. EE.UU.: la guerra tecnológica se desata."
+image: "https://img.youtube.com/vi/Hi6L497r2Ss/hqdefault.jpg"
+image_alt: "CULTURAFREAK #007"
+resumen: "Huawei vs. EE.UU.: la guerra tecnológica se desata."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Hi6L497r2Ss"
+youtube_url: "https://www.youtube.com/watch?v=Hi6L497r2Ss"
+---
+
+Huawei vs. EE.UU.: la guerra tecnológica se desata.
+
+
+En este episodio repasamos el bloqueo total a Huawei por parte de empresas americanas, desde Google hasta ARM, y cómo se desmorona su ecosistema. Pero no todo es tensión internacional: hablamos también de drones espías, WWDC 2019, contraseñas sin cifrar de Google, edición de vídeo móvil con Adobe, Minecraft en realidad aumentada, procesadores Ryzen, hacks masivos, Instagram rindiéndose al vídeo horizontal y los primeros satélites de Starlink. Ah, y puedes mandar tu nombre a Marte. Literalmente.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Hi6L497r2Ss" title="CULTURAFREAK #007" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-008.md
+++ b/_posts/2025-05-29-culturafreak-008.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #008"
+date: 2025-05-29 09:00:00 -0400
+description: "Semana tranquila pero con titulares curiosos: Elementor celebra su cumpleaños con descuento, Microsoft actualiza Excel para iOS con escaneo de hojas, y Dropbox sube precios..."
+image: "https://img.youtube.com/vi/X76Gl84qB2c/hqdefault.jpg"
+image_alt: "CULTURAFREAK #008"
+resumen: "Semana tranquila pero con titulares curiosos: Elementor celebra su cumpleaños con descuento, Microsoft actualiza Excel para iOS con escaneo de hojas, y Dropbox sube precios..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "X76Gl84qB2c"
+youtube_url: "https://www.youtube.com/watch?v=X76Gl84qB2c"
+---
+
+Semana tranquila pero con titulares curiosos: Elementor celebra su cumpleaños con descuento, Microsoft actualiza Excel para iOS con escaneo de hojas, y Dropbox sube precios mientras añade funciones nuevas. También repasamos novedades en Squarespace, un hackeo a Flipboard y el aviso: se viene la WWDC 2019, así que prepárate para una avalancha de noticias de Apple.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/X76Gl84qB2c" title="CULTURAFREAK #008" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-009.md
+++ b/_posts/2025-05-29-culturafreak-009.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #009"
+date: 2025-05-29 09:00:00 -0400
+description: "Huawei mete anuncios en la pantalla de bloqueo, Facebook lanza su propia criptomoneda (Libra) y Apple apuesta fuerte por la privacidad con “Sign in with Apple”. Además..."
+image: "https://img.youtube.com/vi/Tjpgar-cEh8/hqdefault.jpg"
+image_alt: "CULTURAFREAK #009"
+resumen: "Huawei mete anuncios en la pantalla de bloqueo, Facebook lanza su propia criptomoneda (Libra) y Apple apuesta fuerte por la privacidad con “Sign in with Apple”. Además..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Tjpgar-cEh8"
+youtube_url: "https://www.youtube.com/watch?v=Tjpgar-cEh8"
+---
+
+Huawei mete anuncios en la pantalla de bloqueo, Facebook lanza su propia criptomoneda (Libra) y Apple apuesta fuerte por la privacidad con “Sign in with Apple”. Además: Remove.bg lanza app de escritorio, un robot de cocina espía con micro oculto, y dos trucos útiles para tunear tu web en Squarespace. Mucha tecnología, un poco de paranoia y unas pinceladas de diseño web.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Tjpgar-cEh8" title="CULTURAFREAK #009" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-010.md
+++ b/_posts/2025-05-29-culturafreak-010.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #010"
+date: 2025-05-29 09:00:00 -0400
+description: "Bitcoin supera los $10,000, Mario se mete al Battle Royale y Google… roba letras de canciones (pillados con código morse, literal). Esta semana también hablamos del nuevo juego..."
+image: "https://img.youtube.com/vi/FmtQkkqFVWw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #010"
+resumen: "Bitcoin supera los $10,000, Mario se mete al Battle Royale y Google… roba letras de canciones (pillados con código morse, literal). Esta semana también hablamos del nuevo juego..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "FmtQkkqFVWw"
+youtube_url: "https://www.youtube.com/watch?v=FmtQkkqFVWw"
+---
+
+Bitcoin supera los $10,000, Mario se mete al Battle Royale y Google… roba letras de canciones (pillados con código morse, literal). Esta semana también hablamos del nuevo juego para Tesla, Microsoft To-Do en Mac, antivirus en las SmartTV de Samsung, drama en Venmo y el adiós de Google a las tablets. Además, dos artículos en el blog: cómo crear tu web en 5 minutos y cuándo usar !important en Squarespace.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/FmtQkkqFVWw" title="CULTURAFREAK #010" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-011.md
+++ b/_posts/2025-05-29-culturafreak-011.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "CULTURAFREAK #011"
+date: 2025-05-29 09:00:00 -0400
+description: "Trump levanta el veto a Huawei, Mozilla lanza una web para trolear anunciantes y Xiaomi presenta un móvil “solo para mujeres” con filtros para selfies (facepalm)."
+image: "https://img.youtube.com/vi/pwDtZT86Suk/hqdefault.jpg"
+image_alt: "CULTURAFREAK #011"
+resumen: "Trump levanta el veto a Huawei, Mozilla lanza una web para trolear anunciantes y Xiaomi presenta un móvil “solo para mujeres” con filtros para selfies (facepalm)."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "pwDtZT86Suk"
+youtube_url: "https://www.youtube.com/watch?v=pwDtZT86Suk"
+---
+
+Trump levanta el veto a Huawei, Mozilla lanza una web para trolear anunciantes y Xiaomi presenta un móvil “solo para mujeres” con filtros para selfies (facepalm). 
+
+
+Además: cifrado fácil con Hat.sh, un mapa freak de faros europeos, Excel vulnerable a malware, Candy Crush sigue arrasando y SpaceX lo vuelve a petar (casi). También hablamos del adiós de Jony Ive y la llegada de Andrew Kim a Apple.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/pwDtZT86Suk" title="CULTURAFREAK #011" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-012.md
+++ b/_posts/2025-05-29-culturafreak-012.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #012"
+date: 2025-05-29 09:00:00 -0400
+description: "Neuralink de Elon Musk quiere conectar tu cerebro a una máquina, Apple se queda con el negocio 5G de Intel y Slack se pone más rápido y usable offline. También repasamos el..."
+image: "https://img.youtube.com/vi/OzSLcbuiANw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #012"
+resumen: "Neuralink de Elon Musk quiere conectar tu cerebro a una máquina, Apple se queda con el negocio 5G de Intel y Slack se pone más rápido y usable offline. También repasamos el..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "OzSLcbuiANw"
+youtube_url: "https://www.youtube.com/watch?v=OzSLcbuiANw"
+---
+
+Neuralink de Elon Musk quiere conectar tu cerebro a una máquina, Apple se queda con el negocio 5G de Intel y Slack se pone más rápido y usable offline. También repasamos el crecimiento inesperado de Snapchat, la pausa de Libra, y un puñado de sustos de privacidad: brechas en VLC, fallos en Messenger Kids y una multa para Google por espiar redes WiFi. Si viste El Gran Hackeo, descarga Jumbo Privacy… y respira hondo.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/OzSLcbuiANw" title="CULTURAFREAK #012" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-013.md
+++ b/_posts/2025-05-29-culturafreak-013.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #013"
+date: 2025-05-29 09:00:00 -0400
+description: "Alexa se mete en tus gafas (y en tu dedo), Facebook lanza su propio “Ready Player One” con Horizon, y los Surface Neo y Duo de Microsoft apuestan por lo arriesgado. También..."
+image: "https://img.youtube.com/vi/CGU_fzv-Gco/hqdefault.jpg"
+image_alt: "CULTURAFREAK #013"
+resumen: "Alexa se mete en tus gafas (y en tu dedo), Facebook lanza su propio “Ready Player One” con Horizon, y los Surface Neo y Duo de Microsoft apuestan por lo arriesgado. También..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "CGU_fzv-Gco"
+youtube_url: "https://www.youtube.com/watch?v=CGU_fzv-Gco"
+---
+
+Alexa se mete en tus gafas (y en tu dedo), Facebook lanza su propio “Ready Player One” con Horizon, y los Surface Neo y Duo de Microsoft apuestan por lo arriesgado. También repasamos vigilancia en buses de Madrid, servidores ocultos en búnkeres de la OTAN, espionaje interno en Yahoo, y la guerra abierta entre Facebook, la privacidad y… el sentido común. Además, el WiFi cumple 20 años y Cloudflare lanza Warp, su VPN gratuita centrada en la privacidad.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/CGU_fzv-Gco" title="CULTURAFREAK #013" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-014.md
+++ b/_posts/2025-05-29-culturafreak-014.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #014"
+date: 2025-05-29 09:00:00 -0400
+description: "WhatsApp empieza a banear grupos por bromas pesadas, macOS Catalina ya está disponible y Adobe se apaga en Venezuela por orden presidencial. La criptomoneda de Facebook pierde..."
+image: "https://img.youtube.com/vi/C4RJWCPSiBs/hqdefault.jpg"
+image_alt: "CULTURAFREAK #014"
+resumen: "WhatsApp empieza a banear grupos por bromas pesadas, macOS Catalina ya está disponible y Adobe se apaga en Venezuela por orden presidencial. La criptomoneda de Facebook pierde..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "C4RJWCPSiBs"
+youtube_url: "https://www.youtube.com/watch?v=C4RJWCPSiBs"
+---
+
+WhatsApp empieza a banear grupos por bromas pesadas, macOS Catalina ya está disponible y Adobe se apaga en Venezuela por orden presidencial. La criptomoneda de Facebook pierde a casi todos sus aliados antes de salir y Apple TV+ se refuerza con una secuela de “Band of Brothers”. Además, repasamos los EyeEm Awards 2019 y la preocupante crisis del vapeo en EE.UU. Spoiler: 2020 ya se veía venir.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/C4RJWCPSiBs" title="CULTURAFREAK #014" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-015.md
+++ b/_posts/2025-05-29-culturafreak-015.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #015"
+date: 2025-05-29 09:00:00 -0400
+description: "EE.UU. actualiza su sistema nuclear… que aún usaba disquetes. Una capa de invisibilidad estilo Harry Potter es real (gracias, HyperStealth), y Google Photos da almacenamiento..."
+image: "https://img.youtube.com/vi/n2QphTDMT-4/hqdefault.jpg"
+image_alt: "CULTURAFREAK #015"
+resumen: "EE.UU. actualiza su sistema nuclear… que aún usaba disquetes. Una capa de invisibilidad estilo Harry Potter es real (gracias, HyperStealth), y Google Photos da almacenamiento..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "n2QphTDMT-4"
+youtube_url: "https://www.youtube.com/watch?v=n2QphTDMT-4"
+---
+
+EE.UU. actualiza su sistema nuclear… que aún usaba disquetes. Una capa de invisibilidad estilo Harry Potter es real (gracias, HyperStealth), y Google Photos da almacenamiento gratis a iPhones por error. También repasamos 2.500 juegos clásicos de MS-DOS jugables online, el caos en Libra, la publicidad retroactiva de Tencent, pulseras para rezar en el Vaticano y los nuevos trajes de la NASA. Spoiler: la NASA tampoco se fía mucho de SpaceX ni de Boeing.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/n2QphTDMT-4" title="CULTURAFREAK #015" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-016.md
+++ b/_posts/2025-05-29-culturafreak-016.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #016"
+date: 2025-05-29 09:00:00 -0400
+description: "Zuckerberg se enfrenta al Congreso por Libra, Google se queda sin espacio (literalmente), y la BBC entra en la Dark Web para esquivar censuras. Esta semana también hablamos del..."
+image: "https://img.youtube.com/vi/lw_IjfQ-1fI/hqdefault.jpg"
+image_alt: "CULTURAFREAK #016"
+resumen: "Zuckerberg se enfrenta al Congreso por Libra, Google se queda sin espacio (literalmente), y la BBC entra en la Dark Web para esquivar censuras. Esta semana también hablamos del..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "lw_IjfQ-1fI"
+youtube_url: "https://www.youtube.com/watch?v=lw_IjfQ-1fI"
+---
+
+Zuckerberg se enfrenta al Congreso por Libra, Google se queda sin espacio (literalmente), y la BBC entra en la Dark Web para esquivar censuras. Esta semana también hablamos del modo oscuro y su impacto real en la batería, los ingresos millonarios de Cristiano en Instagram, la web que predice cuándo vas a morir, el satélite selfie de Samsung que acaba en una granja y el debut bursátil de Virgin Galactic. Ah, y Google afirma haber alcanzado la supremacía cuántica. Casi nada.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/lw_IjfQ-1fI" title="CULTURAFREAK #016" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-017.md
+++ b/_posts/2025-05-29-culturafreak-017.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #017"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple rompe récords financieros, Google compra Fitbit y Amazon se mete de lleno en el negocio de las noticias (y abre centros de datos en España). Hablamos también del avance..."
+image: "https://img.youtube.com/vi/t4cdW4BE4Wo/hqdefault.jpg"
+image_alt: "CULTURAFREAK #017"
+resumen: "Apple rompe récords financieros, Google compra Fitbit y Amazon se mete de lleno en el negocio de las noticias (y abre centros de datos en España). Hablamos también del avance..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "t4cdW4BE4Wo"
+youtube_url: "https://www.youtube.com/watch?v=t4cdW4BE4Wo"
+---
+
+Apple rompe récords financieros, Google compra Fitbit y Amazon se mete de lleno en el negocio de las noticias (y abre centros de datos en España). Hablamos también del avance de la criptomoneda de Telegram, el rastreo móvil del INE, la compra de Unfold por Squarespace, y la decisión de Twitter de prohibir los anuncios políticos. Cerramos con ciberespionaje olímpico: Microsoft acusa a Rusia de hackear los Juegos de Tokio 2020.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/t4cdW4BE4Wo" title="CULTURAFREAK #017" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-018.md
+++ b/_posts/2025-05-29-culturafreak-018.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #018"
+date: 2025-05-29 09:00:00 -0400
+description: "Facebook cambia de logo, TikTok supera los 1.000 millones de usuarios y Apple TV+ sorprende con una calidad de vídeo superior a Netflix. Además, DuckDuckGo sigue ganando..."
+image: "https://img.youtube.com/vi/W4EpH6R_pMA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #018"
+resumen: "Facebook cambia de logo, TikTok supera los 1.000 millones de usuarios y Apple TV+ sorprende con una calidad de vídeo superior a Netflix. Además, DuckDuckGo sigue ganando..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "W4EpH6R_pMA"
+youtube_url: "https://www.youtube.com/watch?v=W4EpH6R_pMA"
+---
+
+Facebook cambia de logo, TikTok supera los 1.000 millones de usuarios y Apple TV+ sorprende con una calidad de vídeo superior a Netflix. Además, DuckDuckGo sigue ganando terreno como buscador privado, WhatsApp Business lanza catálogos, y una red de tráfico de personas operaba impunemente por Instagram. Cerramos con un Mustang eléctrico de 900CV, excusas automáticas para brechas de seguridad, y herramientas útiles como Namech_k y mapas 3D de población mundial.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/W4EpH6R_pMA" title="CULTURAFREAK #018" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-019.md
+++ b/_posts/2025-05-29-culturafreak-019.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #019"
+date: 2025-05-29 09:00:00 -0400
+description: "¿Adicto al móvil? Google propone que lo cambies por una hoja de papel. Facebook lanza su sistema de pagos y GitHub planea guardar el código abierto… en el Ártico. Además, Apple..."
+image: "https://img.youtube.com/vi/kE1_cYVm0BM/hqdefault.jpg"
+image_alt: "CULTURAFREAK #019"
+resumen: "¿Adicto al móvil? Google propone que lo cambies por una hoja de papel. Facebook lanza su sistema de pagos y GitHub planea guardar el código abierto… en el Ártico. Además, Apple..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "kE1_cYVm0BM"
+youtube_url: "https://www.youtube.com/watch?v=kE1_cYVm0BM"
+---
+
+¿Adicto al móvil? Google propone que lo cambies por una hoja de papel. Facebook lanza su sistema de pagos y GitHub planea guardar el código abierto… en el Ártico. Además, Apple elimina todas las apps de vapeo, miles de cuentas de Disney+ son hackeadas, y el formato arruinado de Los Simpson enfurece a los fans. Cerramos con FreddieMeter, la web que te dice cuánto te pareces cantando a Freddie Mercury. Spoiler: mejor no te emociones.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/kE1_cYVm0BM" title="CULTURAFREAK #019" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-020.md
+++ b/_posts/2025-05-29-culturafreak-020.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #020"
+date: 2025-05-29 09:00:00 -0400
+description: "Tesla presenta su brutal CyberTruck, EE.UU. vuelve a darle una prórroga a Huawei y SpaceX ve cómo su Starship explota durante pruebas. Además, Mailchimp lanza un creador de..."
+image: "https://img.youtube.com/vi/Anu57A5MQOw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #020"
+resumen: "Tesla presenta su brutal CyberTruck, EE.UU. vuelve a darle una prórroga a Huawei y SpaceX ve cómo su Starship explota durante pruebas. Además, Mailchimp lanza un creador de..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Anu57A5MQOw"
+youtube_url: "https://www.youtube.com/watch?v=Anu57A5MQOw"
+---
+
+Tesla presenta su brutal CyberTruck, EE.UU. vuelve a darle una prórroga a Huawei y SpaceX ve cómo su Starship explota durante pruebas. Además, Mailchimp lanza un creador de webs, Generated Photos te ofrece 100.000 caras falsas gratis, y Google Cloud Print tiene los días contados. También repasamos lo nuevo de Spark, un verificador para el Black Friday, un juego donde eres tatuador… y sí, un perro conduciendo un coche en Florida. Literal.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Anu57A5MQOw" title="CULTURAFREAK #020" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-021.md
+++ b/_posts/2025-05-29-culturafreak-021.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #021"
+date: 2025-05-29 09:00:00 -0400
+description: "Vuelve CULTURAFREAK con una edición marcada por el COVID-19: se cancelan el MWC, la GDC y el F8, y están en duda Google I/O, WWDC, E3 y hasta los Juegos Olímpicos. Además..."
+image: "https://img.youtube.com/vi/TVE2omGqvg0/hqdefault.jpg"
+image_alt: "CULTURAFREAK #021"
+resumen: "Vuelve CULTURAFREAK con una edición marcada por el COVID-19: se cancelan el MWC, la GDC y el F8, y están en duda Google I/O, WWDC, E3 y hasta los Juegos Olímpicos. Además..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "TVE2omGqvg0"
+youtube_url: "https://www.youtube.com/watch?v=TVE2omGqvg0"
+---
+
+Vuelve CULTURAFREAK con una edición marcada por el COVID-19: se cancelan el MWC, la GDC y el F8, y están en duda Google I/O, WWDC, E3 y hasta los Juegos Olímpicos. Además, Plague Inc. es eliminado en China, Brave se alía con Internet Archive contra el error 404, y el terraplanista Mike Hughes muere en pleno intento de “demostrar” su teoría. También hablamos de Shopify entrando en Libra, el Barça lanzando su blockchain, millones de fotos del Smithsonian liberadas… y grupos de WhatsApp indexados por Google. Caótica y cargada.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/TVE2omGqvg0" title="CULTURAFREAK #021" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-022.md
+++ b/_posts/2025-05-29-culturafreak-022.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #022"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple lanza el nuevo iPhone SE 2020 con potencia de iPhone 11 y precio ajustado, mientras Visual Studio Code se actualiza con mejoras para desarrolladores. También repasamos el..."
+image: "https://img.youtube.com/vi/-jjFuGPf-Uw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #022"
+resumen: "Apple lanza el nuevo iPhone SE 2020 con potencia de iPhone 11 y precio ajustado, mientras Visual Studio Code se actualiza con mejoras para desarrolladores. También repasamos el..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "-jjFuGPf-Uw"
+youtube_url: "https://www.youtube.com/watch?v=-jjFuGPf-Uw"
+---
+
+Apple lanza el nuevo iPhone SE 2020 con potencia de iPhone 11 y precio ajustado, mientras Visual Studio Code se actualiza con mejoras para desarrolladores. También repasamos el hackeo a Aptoide, los fallos de seguridad de Zoom y la fecha del primer viaje tripulado de SpaceX. Además, la NASA planea construir un telescopio en la cara oculta de la Luna y… sí, existe una web para simular el sonido ambiente de una oficina. Porque 2020 no deja de sorprender.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/-jjFuGPf-Uw" title="CULTURAFREAK #022" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-023.md
+++ b/_posts/2025-05-29-culturafreak-023.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #023"
+date: 2025-05-29 09:00:00 -0400
+description: "Semana de WWDC 2020: Apple lo acapara todo, sus acciones rompen máximos históricos y los rumores vuelan. Facebook cambia de rumbo con Libra, que deja de ser criptomoneda para..."
+image: "https://img.youtube.com/vi/FVMXVxgHZJM/hqdefault.jpg"
+image_alt: "CULTURAFREAK #023"
+resumen: "Semana de WWDC 2020: Apple lo acapara todo, sus acciones rompen máximos históricos y los rumores vuelan. Facebook cambia de rumbo con Libra, que deja de ser criptomoneda para..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "FVMXVxgHZJM"
+youtube_url: "https://www.youtube.com/watch?v=FVMXVxgHZJM"
+---
+
+Semana de WWDC 2020: Apple lo acapara todo, sus acciones rompen máximos históricos y los rumores vuelan. Facebook cambia de rumbo con Libra, que deja de ser criptomoneda para convertirse en sistema de pagos. También repasamos el auge de TikTok entre menores, la llegada de Bootstrap 5.0, los satélites Starlink en tiempo real y cómo Zoom finalmente cifrará todas sus llamadas. Empieza el verano, pero las noticias tech no descansan.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/FVMXVxgHZJM" title="CULTURAFREAK #023" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-024.md
+++ b/_posts/2025-05-29-culturafreak-024.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #024"
+date: 2025-05-29 09:00:00 -0400
+description: "Vuelve CULTURAFREAK con una edición cargada de Elon Musk: Tesla dispara en bolsa, Neuralink presenta avances para conectar el cerebro a chips, SpaceX sigue haciendo historia y..."
+image: "https://img.youtube.com/vi/xmI7uwDWkbw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #024"
+resumen: "Vuelve CULTURAFREAK con una edición cargada de Elon Musk: Tesla dispara en bolsa, Neuralink presenta avances para conectar el cerebro a chips, SpaceX sigue haciendo historia y..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "xmI7uwDWkbw"
+youtube_url: "https://www.youtube.com/watch?v=xmI7uwDWkbw"
+---
+
+Vuelve CULTURAFREAK con una edición cargada de Elon Musk: Tesla dispara en bolsa, Neuralink presenta avances para conectar el cerebro a chips, SpaceX sigue haciendo historia y Starlink ya ofrece velocidades decentes en sus pruebas. También repasamos la guerra Epic vs. Apple, la salida a bolsa de Coinbase, nuevas funciones curiosas en LinkedIn y un simulador web para jugar con la gravedad y crear tu propio universo. Ah, y un tip útil para firmar PDFs desde el iPad.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/xmI7uwDWkbw" title="CULTURAFREAK #024" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-025.md
+++ b/_posts/2025-05-29-culturafreak-025.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #025"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple anuncia su evento “Time Flies”, pero todo apunta a que no veremos el iPhone 12… aún. Mascarillas oficiales de Apple, novedades en Elementor 3.0, y el Gobierno español..."
+image: "https://img.youtube.com/vi/kfbWpGVvxfs/hqdefault.jpg"
+image_alt: "CULTURAFREAK #025"
+resumen: "Apple anuncia su evento “Time Flies”, pero todo apunta a que no veremos el iPhone 12… aún. Mascarillas oficiales de Apple, novedades en Elementor 3.0, y el Gobierno español..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "kfbWpGVvxfs"
+youtube_url: "https://www.youtube.com/watch?v=kfbWpGVvxfs"
+---
+
+Apple anuncia su evento “Time Flies”, pero todo apunta a que no veremos el iPhone 12… aún. Mascarillas oficiales de Apple, novedades en Elementor 3.0, y el Gobierno español publica el código de RadarCovid. También hablamos de un cohete chino estrellado cerca de un colegio, accesos directos útiles para Google Docs, y el esperado pack de suscripción Apple One. Tecnología, pandemias y un toque de apocalipsis espacial: CULTURAFREAK vuelve al ataque.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/kfbWpGVvxfs" title="CULTURAFREAK #025" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-026.md
+++ b/_posts/2025-05-29-culturafreak-026.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #026"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple presenta nuevos Apple Watch, iPads y el esperado Apple One en su evento “Time Flies”. Nvidia compra ARM por $40.000 millones, y Amazon ficha al exdirector de la NSA, lo..."
+image: "https://img.youtube.com/vi/12_xZxGgaKk/hqdefault.jpg"
+image_alt: "CULTURAFREAK #026"
+resumen: "Apple presenta nuevos Apple Watch, iPads y el esperado Apple One en su evento “Time Flies”. Nvidia compra ARM por $40.000 millones, y Amazon ficha al exdirector de la NSA, lo..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "12_xZxGgaKk"
+youtube_url: "https://www.youtube.com/watch?v=12_xZxGgaKk"
+---
+
+Apple presenta nuevos Apple Watch, iPads y el esperado Apple One en su evento “Time Flies”. Nvidia compra ARM por $40.000 millones, y Amazon ficha al exdirector de la NSA, lo que hace que hasta Snowden levante las cejas. Además, hablamos de la PS5 (con precio y fecha), la Kalashnikov con WiFi, móviles confundidos por los incendios de California y el próximo evento de Google con el Pixel 5 como protagonista. Tecnología, poder y fuego… en todos los sentidos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/12_xZxGgaKk" title="CULTURAFREAK #026" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-027.md
+++ b/_posts/2025-05-29-culturafreak-027.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #027"
+date: 2025-05-29 09:00:00 -0400
+description: "Amazon presenta su dron espía doméstico, widgets personalizables revolucionan iOS 14 (y llenan los bolsillos de un diseñador), y Nintendo dice adiós a la 3DS. Kasparov pierde..."
+image: "https://img.youtube.com/vi/Qf38hmd7H5I/hqdefault.jpg"
+image_alt: "CULTURAFREAK #027"
+resumen: "Amazon presenta su dron espía doméstico, widgets personalizables revolucionan iOS 14 (y llenan los bolsillos de un diseñador), y Nintendo dice adiós a la 3DS. Kasparov pierde..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Qf38hmd7H5I"
+youtube_url: "https://www.youtube.com/watch?v=Qf38hmd7H5I"
+---
+
+Amazon presenta su dron espía doméstico, widgets personalizables revolucionan iOS 14 (y llenan los bolsillos de un diseñador), y Nintendo dice adiós a la 3DS. Kasparov pierde una partida por culpa del ratón, un televisor viejo deja a un pueblo entero sin internet, y DuckDuckGo sigue creciendo sin espiar a nadie. Además: Facebook lanza su “Infinite Office” en VR y Cloudflare se alía con Internet Archive para que el 404 no sea el final del camino.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Qf38hmd7H5I" title="CULTURAFREAK #027" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-028.md
+++ b/_posts/2025-05-29-culturafreak-028.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #028"
+date: 2025-05-29 09:00:00 -0400
+description: "Amazon pone fecha al Prime Day 2020, Apple anuncia cuándo presentará sus resultados del Q4 y Google lanza un Pixel 5 que no sabe si es gama media o alta. El Museo del Prado..."
+image: "https://img.youtube.com/vi/JEEZ-5-U5fs/hqdefault.jpg"
+image_alt: "CULTURAFREAK #028"
+resumen: "Amazon pone fecha al Prime Day 2020, Apple anuncia cuándo presentará sus resultados del Q4 y Google lanza un Pixel 5 que no sabe si es gama media o alta. El Museo del Prado..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "JEEZ-5-U5fs"
+youtube_url: "https://www.youtube.com/watch?v=JEEZ-5-U5fs"
+---
+
+Amazon pone fecha al Prime Day 2020, Apple anuncia cuándo presentará sus resultados del Q4 y Google lanza un Pixel 5 que no sabe si es gama media o alta. El Museo del Prado aterriza en TikTok con éxito, VS Code ya domina entre los desarrolladores y Microsoft lanza su portátil barato, el Surface Laptop Go. Además: robots diseñan ciudades en Minecraft, y Google vuelve a quedar en evidencia con resultados ofensivos en su buscador de imágenes. Cultura digital, tecnología y un poco de vergüenza ajena.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/JEEZ-5-U5fs" title="CULTURAFREAK #028" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-029.md
+++ b/_posts/2025-05-29-culturafreak-029.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #029"
+date: 2025-05-29 09:00:00 -0400
+description: "Semana de Keynote: Apple presenta toda la familia iPhone 12 y el HomePod Mini. Mientras tanto, John McAfee es detenido en España por evasión de impuestos, Google rebautiza..."
+image: "https://img.youtube.com/vi/sx5eAr13fkk/hqdefault.jpg"
+image_alt: "CULTURAFREAK #029"
+resumen: "Semana de Keynote: Apple presenta toda la familia iPhone 12 y el HomePod Mini. Mientras tanto, John McAfee es detenido en España por evasión de impuestos, Google rebautiza..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "sx5eAr13fkk"
+youtube_url: "https://www.youtube.com/watch?v=sx5eAr13fkk"
+---
+
+Semana de Keynote: Apple presenta toda la familia iPhone 12 y el HomePod Mini. Mientras tanto, John McAfee es detenido en España por evasión de impuestos, Google rebautiza GSuite como Google Workspace y lanza su herramienta para verificar noticias. También: una tarjeta de crédito gamer que brilla al pagar, problemas de oxígeno en la ISS, una bomba de la Segunda Guerra detona en Polonia y el impactante uso de IA para revivir a una víctima del tiroteo de Parkland. Tecnología, marketing y distopías… como debe ser.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/sx5eAr13fkk" title="CULTURAFREAK #029" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-030.md
+++ b/_posts/2025-05-29-culturafreak-030.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #030"
+date: 2025-05-29 09:00:00 -0400
+description: "Muere el presidente de Samsung, Adobe lanza Illustrator para iPad y Airbnb ficha a Jony Ive para rediseñar su experiencia de usuario. También hablamos de Halide Mark II en..."
+image: "https://img.youtube.com/vi/0esVrGOx2gk/hqdefault.jpg"
+image_alt: "CULTURAFREAK #030"
+resumen: "Muere el presidente de Samsung, Adobe lanza Illustrator para iPad y Airbnb ficha a Jony Ive para rediseñar su experiencia de usuario. También hablamos de Halide Mark II en..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "0esVrGOx2gk"
+youtube_url: "https://www.youtube.com/watch?v=0esVrGOx2gk"
+---
+
+Muere el presidente de Samsung, Adobe lanza Illustrator para iPad y Airbnb ficha a Jony Ive para rediseñar su experiencia de usuario. También hablamos de Halide Mark II en iPhone 12, cuentas obligatorias de Microsoft para jugar a Minecraft, y cómo una bolsa de té ayudó a detectar una fuga de oxígeno en la Estación Espacial Internacional. Además, la sonda Osiris-Rex recoge material de un asteroide y te presentamos una herramienta gratuita para crear menús QR en segundos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/0esVrGOx2gk" title="CULTURAFREAK #030" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-031.md
+++ b/_posts/2025-05-29-culturafreak-031.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #031"
+date: 2025-05-29 09:00:00 -0400
+description: "¡Hay agua en la Luna! La NASA detecta hielo en zonas sombrías de la superficie lunar, y Apple lanza oficialmente Apple One, su pack de servicios todo-en-uno. También repasamos..."
+image: "https://img.youtube.com/vi/Zw289OSQn8s/hqdefault.jpg"
+image_alt: "CULTURAFREAK #031"
+resumen: "¡Hay agua en la Luna! La NASA detecta hielo en zonas sombrías de la superficie lunar, y Apple lanza oficialmente Apple One, su pack de servicios todo-en-uno. También repasamos..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Zw289OSQn8s"
+youtube_url: "https://www.youtube.com/watch?v=Zw289OSQn8s"
+---
+
+¡Hay agua en la Luna! La NASA detecta hielo en zonas sombrías de la superficie lunar, y Apple lanza oficialmente Apple One, su pack de servicios todo-en-uno. También repasamos precios y condiciones de la beta de Starlink, la IA que confunde un balón con la calva del linier, la subida de precios de Netflix en EE.UU. y el regalo más bizarro de Kanye West: un holograma del padre fallecido de Kim Kardashian… alabándolo a él mismo. Ciencia, tecnología y ego a partes iguales.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Zw289OSQn8s" title="CULTURAFREAK #031" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-032.md
+++ b/_posts/2025-05-29-culturafreak-032.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #032"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple anuncia su keynote “One More Thing” para presentar los primeros Macs con Apple Silicon, mientras Elon Musk convierte una broma en realidad vendiendo tequila a $250 la..."
+image: "https://img.youtube.com/vi/GMvNepygGEc/hqdefault.jpg"
+image_alt: "CULTURAFREAK #032"
+resumen: "Apple anuncia su keynote “One More Thing” para presentar los primeros Macs con Apple Silicon, mientras Elon Musk convierte una broma en realidad vendiendo tequila a $250 la..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "GMvNepygGEc"
+youtube_url: "https://www.youtube.com/watch?v=GMvNepygGEc"
+---
+
+Apple anuncia su keynote “One More Thing” para presentar los primeros Macs con Apple Silicon, mientras Elon Musk convierte una broma en realidad vendiendo tequila a $250 la botella. Además, descubrimos los 20 códigos de desbloqueo más usados, el Baby Shark destrona a Despacito en YouTube y Samsung busca dominar la gama media con sus chips Exynos. También te recomendamos un emulador retro sin anuncios, un experimento fotográfico curioso y la web más marciana (literal) de Kanye West: KANYE2049.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/GMvNepygGEc" title="CULTURAFREAK #032" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-033.md
+++ b/_posts/2025-05-29-culturafreak-033.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #033"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple lanza sus primeros Mac con chip M1 y promete revolucionar el ecosistema. Affinity se adelanta a Adobe y adapta toda su suite creativa a macOS Big Sur y Apple Silicon..."
+image: "https://img.youtube.com/vi/pMa63YepgTw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #033"
+resumen: "Apple lanza sus primeros Mac con chip M1 y promete revolucionar el ecosistema. Affinity se adelanta a Adobe y adapta toda su suite creativa a macOS Big Sur y Apple Silicon..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "pMa63YepgTw"
+youtube_url: "https://www.youtube.com/watch?v=pMa63YepgTw"
+---
+
+Apple lanza sus primeros Mac con chip M1 y promete revolucionar el ecosistema. Affinity se adelanta a Adobe y adapta toda su suite creativa a macOS Big Sur y Apple Silicon desde el primer día. También hablamos de una app de Apple Watch aprobada para combatir pesadillas, del fin del almacenamiento ilimitado en Google Fotos, y de cómo un iPhone 12 volador demuestra su estabilizador. Además: TestFlight mejora por fin su sistema de actualizaciones y PayPal entra de lleno en el mundo de las criptos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/pMa63YepgTw" title="CULTURAFREAK #033" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-034.md
+++ b/_posts/2025-05-29-culturafreak-034.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #034"
+date: 2025-05-29 09:00:00 -0400
+description: "SpaceX lleva a cuatro astronautas a la ISS (incluyendo un peluche de Baby Yoda) y Tom Cruise confirma que rodará en el espacio. Esta semana también hablamos de Fleets, las..."
+image: "https://img.youtube.com/vi/xuMH6cdNpH4/hqdefault.jpg"
+image_alt: "CULTURAFREAK #034"
+resumen: "SpaceX lleva a cuatro astronautas a la ISS (incluyendo un peluche de Baby Yoda) y Tom Cruise confirma que rodará en el espacio. Esta semana también hablamos de Fleets, las..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "xuMH6cdNpH4"
+youtube_url: "https://www.youtube.com/watch?v=xuMH6cdNpH4"
+---
+
+SpaceX lleva a cuatro astronautas a la ISS (incluyendo un peluche de Baby Yoda) y Tom Cruise confirma que rodará en el espacio. Esta semana también hablamos de Fleets, las nuevas stories de Twitter que nadie pidió, la IA que simula tu letra con Calligrapher.ai, y el fallido lanzamiento del satélite español Ingenio. Además: un F-22 Raptor en 4K, Shazam revela las canciones más buscadas del mundo, el radiotelescopio de Arecibo se tambalea, y una web que te envía una carta… dentro de 10 años.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/xuMH6cdNpH4" title="CULTURAFREAK #034" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-035.md
+++ b/_posts/2025-05-29-culturafreak-035.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #035"
+date: 2025-05-29 09:00:00 -0400
+description: "AWS se cae y deja sin timbres, aspiradoras y hasta visitas a medio planeta. El radiotelescopio de Arecibo colapsa definitivamente, y descubrimos joyitas como el Ekranoplano..."
+image: "https://img.youtube.com/vi/2GHIj40Nz8A/hqdefault.jpg"
+image_alt: "CULTURAFREAK #035"
+resumen: "AWS se cae y deja sin timbres, aspiradoras y hasta visitas a medio planeta. El radiotelescopio de Arecibo colapsa definitivamente, y descubrimos joyitas como el Ekranoplano..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "2GHIj40Nz8A"
+youtube_url: "https://www.youtube.com/watch?v=2GHIj40Nz8A"
+---
+
+AWS se cae y deja sin timbres, aspiradoras y hasta visitas a medio planeta. El radiotelescopio de Arecibo colapsa definitivamente, y descubrimos joyitas como el Ekranoplano soviético abandonado, una moto eléctrica que rompe récords, y un generador de mundos de fantasía para amantes del rol. Además, pruebas de que el microondas sí interfiere con el WiFi y una joya absoluta: Paintball Karting, o cómo convertir Mario Kart en deporte real. Esta semana, caos, nostalgia y velocidad.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/2GHIj40Nz8A" title="CULTURAFREAK #035" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-036.md
+++ b/_posts/2025-05-29-culturafreak-036.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #036"
+date: 2025-05-29 09:00:00 -0400
+description: "Salesforce compra Slack por 27.700 millones y Apple lanza sus AirPods Max por $549, desatando debates sobre calidad, precio y hype. También repasamos curiosidades como los..."
+image: "https://img.youtube.com/vi/-3wCo4yBcro/hqdefault.jpg"
+image_alt: "CULTURAFREAK #036"
+resumen: "Salesforce compra Slack por 27.700 millones y Apple lanza sus AirPods Max por $549, desatando debates sobre calidad, precio y hype. También repasamos curiosidades como los..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "-3wCo4yBcro"
+youtube_url: "https://www.youtube.com/watch?v=-3wCo4yBcro"
+---
+
+Salesforce compra Slack por 27.700 millones y Apple lanza sus AirPods Max por $549, desatando debates sobre calidad, precio y hype. También repasamos curiosidades como los repartidores de Amazon colgando móviles de los árboles, Microsoft sacando un jersey feo inspirado en Paint, y Elon Musk convirtiéndose en el segundo hombre más rico del mundo. Además: Norton compra Avira, Amazon entra en el negocio farmacéutico, y Snowden consigue la residencia permanente en Rusia. Navidad tech, con su punto de polémica.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/-3wCo4yBcro" title="CULTURAFREAK #036" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-037.md
+++ b/_posts/2025-05-29-culturafreak-037.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #037"
+date: 2025-05-29 09:00:00 -0400
+description: "Elon Musk supera a Jeff Bezos y se convierte en la persona más rica del mundo. Mientras tanto, Jack Ma sigue desaparecido, Samsung prepara el Galaxy S21, y una comparativa..."
+image: "https://img.youtube.com/vi/rlxoYVTmxYQ/hqdefault.jpg"
+image_alt: "CULTURAFREAK #037"
+resumen: "Elon Musk supera a Jeff Bezos y se convierte en la persona más rica del mundo. Mientras tanto, Jack Ma sigue desaparecido, Samsung prepara el Galaxy S21, y una comparativa..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "rlxoYVTmxYQ"
+youtube_url: "https://www.youtube.com/watch?v=rlxoYVTmxYQ"
+---
+
+Elon Musk supera a Jeff Bezos y se convierte en la persona más rica del mundo. Mientras tanto, Jack Ma sigue desaparecido, Samsung prepara el Galaxy S21, y una comparativa revela qué apps de mensajería recopilan más datos. También: MediaTek destrona a Qualcomm, Edge sube posiciones en la guerra de navegadores, y Amazon se compra 11 aviones para su flota. Cerramos con el diseño retro del coche eléctrico Alpha Ace… y un aterrizaje de emergencia digno de película.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/rlxoYVTmxYQ" title="CULTURAFREAK #037" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-038.md
+++ b/_posts/2025-05-29-culturafreak-038.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #038"
+date: 2025-05-29 09:00:00 -0400
+description: "¡AJRA sigue vivo! Y con él, vuelve CULTURAFREAK. Esta semana hablamos del Ever Given desencallado en el Canal de Suez, Ghost 4.0 con soporte para newsletters, y un dock para..."
+image: "https://img.youtube.com/vi/L4P4YQhFrm4/hqdefault.jpg"
+image_alt: "CULTURAFREAK #038"
+resumen: "¡AJRA sigue vivo! Y con él, vuelve CULTURAFREAK. Esta semana hablamos del Ever Given desencallado en el Canal de Suez, Ghost 4.0 con soporte para newsletters, y un dock para..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "L4P4YQhFrm4"
+youtube_url: "https://www.youtube.com/watch?v=L4P4YQhFrm4"
+---
+
+¡AJRA sigue vivo! Y con él, vuelve CULTURAFREAK. Esta semana hablamos del Ever Given desencallado en el Canal de Suez, Ghost 4.0 con soporte para newsletters, y un dock para iPad que cuesta más de lo que esperas. También: tarjetas de presentación NFC, los restos del observatorio de Arecibo, un tip útil para seleccionar emails en iOS, y el épico (y explosivo) aterrizaje de la Starship SN10. Además, Avatar vuelve a ser la película más taquillera y cerramos con recomendación: The Expanse, sci-fi de la buena en Amazon Prime.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/L4P4YQhFrm4" title="CULTURAFREAK #038" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-039.md
+++ b/_posts/2025-05-29-culturafreak-039.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #039"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple presenta sus nuevos iMac de colores con chip M1, iPad Pro con pantalla miniLED, AirTags, Apple TV 4K con nuevo mando y mucho más en su Keynote “Spring Loaded”. Además..."
+image: "https://img.youtube.com/vi/7Dv3Yimad14/hqdefault.jpg"
+image_alt: "CULTURAFREAK #039"
+resumen: "Apple presenta sus nuevos iMac de colores con chip M1, iPad Pro con pantalla miniLED, AirTags, Apple TV 4K con nuevo mando y mucho más en su Keynote “Spring Loaded”. Además..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "7Dv3Yimad14"
+youtube_url: "https://www.youtube.com/watch?v=7Dv3Yimad14"
+---
+
+Apple presenta sus nuevos iMac de colores con chip M1, iPad Pro con pantalla miniLED, AirTags, Apple TV 4K con nuevo mando y mucho más en su Keynote “Spring Loaded”. Además, hablamos del hackeo a The Phone House y el ransomware que afecta a los NAS de QNAP, del simulador online para sentirte hacker de película y del fallecimiento de Michael Collins, el astronauta que no pisó la Luna. Cerramos con historia freak: ¿sabes de dónde viene el término Blockbuster?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/7Dv3Yimad14" title="CULTURAFREAK #039" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-040.md
+++ b/_posts/2025-05-29-culturafreak-040.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #040"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple planea abrir sus propios centros médicos, Windows 11 se filtra antes de tiempo, y los texanos descubren que su aire acondicionado puede ser controlado… por su compañía..."
+image: "https://img.youtube.com/vi/koq--reBFzM/hqdefault.jpg"
+image_alt: "CULTURAFREAK #040"
+resumen: "Apple planea abrir sus propios centros médicos, Windows 11 se filtra antes de tiempo, y los texanos descubren que su aire acondicionado puede ser controlado… por su compañía..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "koq--reBFzM"
+youtube_url: "https://www.youtube.com/watch?v=koq--reBFzM"
+---
+
+Apple planea abrir sus propios centros médicos, Windows 11 se filtra antes de tiempo, y los texanos descubren que su aire acondicionado puede ser controlado… por su compañía eléctrica. También hablamos de la música HiFi que muchos no pueden distinguir, las nuevas funciones de edición de vídeo de Apple, la llegada de Halide al iPad, el lanzamiento de Bootstrap 5 y un proyecto artístico que reúne 2400 animaciones únicas de una simple caminata. Tecnología, arte y distopías veraniegas.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/koq--reBFzM" title="CULTURAFREAK #040" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-041.md
+++ b/_posts/2025-05-29-culturafreak-041.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #041"
+date: 2025-05-29 09:00:00 -0400
+description: "John McAfee es encontrado muerto en una prisión catalana tras aprobarse su extradición a EE.UU. Mientras tanto, Synology lanza DSM 7.0 con mejoras clave en seguridad, Brave..."
+image: "https://img.youtube.com/vi/v1Mb9dBOn-A/hqdefault.jpg"
+image_alt: "CULTURAFREAK #041"
+resumen: "John McAfee es encontrado muerto en una prisión catalana tras aprobarse su extradición a EE.UU. Mientras tanto, Synology lanza DSM 7.0 con mejoras clave en seguridad, Brave..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "v1Mb9dBOn-A"
+youtube_url: "https://www.youtube.com/watch?v=v1Mb9dBOn-A"
+---
+
+John McAfee es encontrado muerto en una prisión catalana tras aprobarse su extradición a EE.UU. Mientras tanto, Synology lanza DSM 7.0 con mejoras clave en seguridad, Brave estrena su propio buscador y ClipDrop nos permite copiar objetos del mundo real mediante realidad aumentada. También repasamos el nostálgico Winamp Skin Museum, la llegada de Game Dev Story+ a Apple Arcade y el nuevo teaser de Fundación en Apple TV+. Ciencia ficción, privacidad y nostalgia en una sola dosis.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/v1Mb9dBOn-A" title="CULTURAFREAK #041" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-042.md
+++ b/_posts/2025-05-29-culturafreak-042.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #042"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple lanza la beta pública de iOS y iPadOS 15, Windows 11 convierte su famosa pantalla azul en negra, y el Pentágono publica un informe sobre OVNIs (sí, en serio). También te..."
+image: "https://img.youtube.com/vi/WEntpDP0umY/hqdefault.jpg"
+image_alt: "CULTURAFREAK #042"
+resumen: "Apple lanza la beta pública de iOS y iPadOS 15, Windows 11 convierte su famosa pantalla azul en negra, y el Pentágono publica un informe sobre OVNIs (sí, en serio). También te..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "WEntpDP0umY"
+youtube_url: "https://www.youtube.com/watch?v=WEntpDP0umY"
+---
+
+Apple lanza la beta pública de iOS y iPadOS 15, Windows 11 convierte su famosa pantalla azul en negra, y el Pentágono publica un informe sobre OVNIs (sí, en serio). También te cuento cómo sacarle partido a Spotlight en tu iPad, te invito a una batalla infinita de clicks en Click Brawl, y te recomiendo un fondo de pantalla freak basado en la tecla CMD. Además, Mosaic en Apple Arcade y Mythic Quest en Apple TV+ son las joyas recomendadas de esta semana. Entre aliens, betas y comedia tech, CULTURAFREAK sigue sumando.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/WEntpDP0umY" title="CULTURAFREAK #042" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-043.md
+++ b/_posts/2025-05-29-culturafreak-043.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #043"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple implementa medidas de protección infantil en iOS 15 usando Machine Learning, generando mucho ruido mediático (y más de un malentendido). Microsoft lanza Windows 365, el..."
+image: "https://img.youtube.com/vi/2yxxpTXHb1c/hqdefault.jpg"
+image_alt: "CULTURAFREAK #043"
+resumen: "Apple implementa medidas de protección infantil en iOS 15 usando Machine Learning, generando mucho ruido mediático (y más de un malentendido). Microsoft lanza Windows 365, el..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "2yxxpTXHb1c"
+youtube_url: "https://www.youtube.com/watch?v=2yxxpTXHb1c"
+---
+
+Apple implementa medidas de protección infantil en iOS 15 usando Machine Learning, generando mucho ruido mediático (y más de un malentendido). Microsoft lanza Windows 365, el Pixel 6 llega con chip propio, y SpaceX monta —y desmonta— el cohete más grande de la historia. Además: redimensiona imágenes con un Atajo de Siri, un militar filtra secretos en un foro de videojuegos, Clubhouse se abre a todos, y celebramos la segunda temporada de Ted Lasso con wallpapers y recomendación incluida. Bonus: Dead Cells, un juegazo que no está en Apple Arcade… pero debería.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/2yxxpTXHb1c" title="CULTURAFREAK #043" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-044.md
+++ b/_posts/2025-05-29-culturafreak-044.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #044"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple renueva su tienda online y Elon Musk presenta el Tesla Bot, dejando claro que Tesla va más allá de los coches. Xiaomi no se queda atrás y lanza el CyberDog, su robot..."
+image: "https://img.youtube.com/vi/nPcvfsarOjM/hqdefault.jpg"
+image_alt: "CULTURAFREAK #044"
+resumen: "Apple renueva su tienda online y Elon Musk presenta el Tesla Bot, dejando claro que Tesla va más allá de los coches. Xiaomi no se queda atrás y lanza el CyberDog, su robot..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "nPcvfsarOjM"
+youtube_url: "https://www.youtube.com/watch?v=nPcvfsarOjM"
+---
+
+Apple renueva su tienda online y Elon Musk presenta el Tesla Bot, dejando claro que Tesla va más allá de los coches. Xiaomi no se queda atrás y lanza el CyberDog, su robot cuadrúpedo con código abierto. Además, Netflix incorpora Audio Espacial en iPhone y iPad, DuckDuckGo lanza direcciones @duck.com para proteger tu privacidad en emails, y un alemán es multado por guardar un tanque de la Segunda Guerra en su garaje. También recomendamos el juego Tetris Beaten Apple Arcade y la serie La costa de los Mosquitos en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/nPcvfsarOjM" title="CULTURAFREAK #044" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-045.md
+++ b/_posts/2025-05-29-culturafreak-045.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #045"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple cumple 10 años bajo el mando de Tim Cook, se estrena el pago directo en tienda desde el iPhone y llegan los dominios personalizados a iCloud. Hablamos del mayor ataque..."
+image: "https://img.youtube.com/vi/CXdsSKenkEo/hqdefault.jpg"
+image_alt: "CULTURAFREAK #045"
+resumen: "Apple cumple 10 años bajo el mando de Tim Cook, se estrena el pago directo en tienda desde el iPhone y llegan los dominios personalizados a iCloud. Hablamos del mayor ataque..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "CXdsSKenkEo"
+youtube_url: "https://www.youtube.com/watch?v=CXdsSKenkEo"
+---
+
+Apple cumple 10 años bajo el mando de Tim Cook, se estrena el pago directo en tienda desde el iPhone y llegan los dominios personalizados a iCloud. Hablamos del mayor ataque DDoS de la historia, los McFlurry rotos que han despertado el interés del gobierno de EE.UU. y el millón de unidades vendidas del Tesla Model 3. Además: ¿sobrevivirías un año en Marte? Recomendamos el juego Layton’s Mystery Journey+ en Apple Arcade y la serie Mr. Corman en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/CXdsSKenkEo" title="CULTURAFREAK #045" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-046.md
+++ b/_posts/2025-05-29-culturafreak-046.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #046"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple celebra el evento California Streaming y Jon Prosser ya se adelanta con filtraciones del supuesto iPhone 14. Analizamos el primer tráiler interactivo de la historia con..."
+image: "https://img.youtube.com/vi/x_NMFI9sDOg/hqdefault.jpg"
+image_alt: "CULTURAFREAK #046"
+resumen: "Apple celebra el evento California Streaming y Jon Prosser ya se adelanta con filtraciones del supuesto iPhone 14. Analizamos el primer tráiler interactivo de la historia con..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "x_NMFI9sDOg"
+youtube_url: "https://www.youtube.com/watch?v=x_NMFI9sDOg"
+---
+
+Apple celebra el evento California Streaming y Jon Prosser ya se adelanta con filtraciones del supuesto iPhone 14. Analizamos el primer tráiler interactivo de la historia con Matrix 4, las nuevas gafas con cámara de Facebook y el castigo a Virgin Galactic. Además: la comparativa de tamaños del Universo, el récord de Tesla en Nürburgring, Asphalt 8+ llega a Apple Arcade, y cerramos con el documental 9/11: Así se vivió en la Casa Blanca en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/x_NMFI9sDOg" title="CULTURAFREAK #046" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-047.md
+++ b/_posts/2025-05-29-culturafreak-047.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #047"
+date: 2025-05-29 09:00:00 -0400
+description: "¡Apple desata novedades! Repasamos todo lo presentado en el evento California Streaming: iPhone 13, iPad mini, Apple Watch Series 7 y más. Además, ya puedes actualizar a iOS 15..."
+image: "https://img.youtube.com/vi/03rybSQltYs/hqdefault.jpg"
+image_alt: "CULTURAFREAK #047"
+resumen: "¡Apple desata novedades! Repasamos todo lo presentado en el evento California Streaming: iPhone 13, iPad mini, Apple Watch Series 7 y más. Además, ya puedes actualizar a iOS 15..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "03rybSQltYs"
+youtube_url: "https://www.youtube.com/watch?v=03rybSQltYs"
+---
+
+¡Apple desata novedades! Repasamos todo lo presentado en el evento California Streaming: iPhone 13, iPad mini, Apple Watch Series 7 y más. Además, ya puedes actualizar a iOS 15 y iPadOS 15. Despedimos al legendario Sir Clive Sinclair, y celebramos la primera misión civil al espacio con Inspiration 4. También echamos un vistazo al pasado con una web que muestra cómo era Internet hace 10 años, y cerramos con Castlevania: Grimoire of Souls en Apple Arcade y el regreso de The Morning Show en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/03rybSQltYs" title="CULTURAFREAK #047" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-048.md
+++ b/_posts/2025-05-29-culturafreak-048.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #048"
+date: 2025-05-29 09:00:00 -0400
+description: "El iPhone 13 ya está en manos de los primeros usuarios y recopilamos las mejores reviews para decidir si merece la pena. Europa quiere imponer el USB-C a todos los móviles..."
+image: "https://img.youtube.com/vi/gCsJZVF8TRA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #048"
+resumen: "El iPhone 13 ya está en manos de los primeros usuarios y recopilamos las mejores reviews para decidir si merece la pena. Europa quiere imponer el USB-C a todos los móviles..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "gCsJZVF8TRA"
+youtube_url: "https://www.youtube.com/watch?v=gCsJZVF8TRA"
+---
+
+El iPhone 13 ya está en manos de los primeros usuarios y recopilamos las mejores reviews para decidir si merece la pena. Europa quiere imponer el USB-C a todos los móviles, China vuelve a la carga contra las criptos, y Facebook… sigue en el fango. Exploramos los nuevos anuncios paralelos de TGI, el uniforme sci-fi de las Fuerzas Espaciales de EE.UU., y una web que visualiza datos de forma brutal. Además, Fundación llega a Apple TV+ y Lego Star Wars Battles aterriza en Apple Arcade.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/gCsJZVF8TRA" title="CULTURAFREAK #048" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-049-r-5trtiixnw.md
+++ b/_posts/2025-05-29-culturafreak-049-r-5trtiixnw.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #049"
+date: 2025-05-29 09:00:00 -0400
+description: "Amazon lanza una avalancha de productos tech, incluyendo un robot estilo Wall-e llamado Astro. Jony Ive se une a Ferrari, Twitter acepta Bitcoin como propina, y Facebook vuelve..."
+image: "https://img.youtube.com/vi/R-5trtiIXNw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #049"
+resumen: "Amazon lanza una avalancha de productos tech, incluyendo un robot estilo Wall-e llamado Astro. Jony Ive se une a Ferrari, Twitter acepta Bitcoin como propina, y Facebook vuelve..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "R-5trtiIXNw"
+youtube_url: "https://www.youtube.com/watch?v=R-5trtiIXNw"
+---
+
+Amazon lanza una avalancha de productos tech, incluyendo un robot estilo Wall-e llamado Astro. Jony Ive se une a Ferrari, Twitter acepta Bitcoin como propina, y Facebook vuelve al centro de la polémica por su trato VIP. Además, hablamos del B-21, el nuevo bombardero indetectable de EE.UU., y de Grover, la plataforma para alquilar gadgets. En videojuegos, celebramos el aniversario de Genshin Impact, y en Apple TV+ la serie recomendada es La historia de Lisey, basada en una novela de Stephen King.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/R-5trtiIXNw" title="CULTURAFREAK #049" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-049.md
+++ b/_posts/2025-05-29-culturafreak-049.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #049"
+date: 2025-05-29 09:00:00 -0400
+description: "Amazon lanza una avalancha de productos tech, incluyendo un robot estilo Wall-e llamado Astro. Jony Ive se une a Ferrari, Twitter acepta Bitcoin como propina, y Facebook vuelve..."
+image: "https://img.youtube.com/vi/nLTT1s3j89g/hqdefault.jpg"
+image_alt: "CULTURAFREAK #049"
+resumen: "Amazon lanza una avalancha de productos tech, incluyendo un robot estilo Wall-e llamado Astro. Jony Ive se une a Ferrari, Twitter acepta Bitcoin como propina, y Facebook vuelve..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "nLTT1s3j89g"
+youtube_url: "https://www.youtube.com/watch?v=nLTT1s3j89g"
+---
+
+Amazon lanza una avalancha de productos tech, incluyendo un robot estilo Wall-e llamado Astro. Jony Ive se une a Ferrari, Twitter acepta Bitcoin como propina, y Facebook vuelve al centro de la polémica por su trato VIP. Además, hablamos del B-21, el nuevo bombardero indetectable de EE.UU., y de Grover, la plataforma para alquilar gadgets. En videojuegos, celebramos el aniversario de Genshin Impact, y en Apple TV+ la serie recomendada es La historia de Lisey, basada en una novela de Stephen King.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/nLTT1s3j89g" title="CULTURAFREAK #049" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-050.md
+++ b/_posts/2025-05-29-culturafreak-050.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #050"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple presenta sus MacBook Pro con los nuevos chips M1 Pro y M1 Max, Google lanza los Pixel 6 con su propio procesador, y Twitch sufre uno de los mayores hackeos de su..."
+image: "https://img.youtube.com/vi/_0iJZN-EjZA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #050"
+resumen: "Apple presenta sus MacBook Pro con los nuevos chips M1 Pro y M1 Max, Google lanza los Pixel 6 con su propio procesador, y Twitch sufre uno de los mayores hackeos de su..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "_0iJZN-EjZA"
+youtube_url: "https://www.youtube.com/watch?v=_0iJZN-EjZA"
+---
+
+Apple presenta sus MacBook Pro con los nuevos chips M1 Pro y M1 Max, Google lanza los Pixel 6 con su propio procesador, y Twitch sufre uno de los mayores hackeos de su historia. Además, hablamos del fenómeno global de El Juego del Calamar, el debut de HBO Max renovado en España, y el viaje espacial del mismísimo Capitán Kirk. En gadgets, destacamos GIPHY Capture y una web para saber dónde acabarías si excavas bajo tus pies. Y en recomendaciones, Only Murders in the Building en Disney+ y NBA 2K22 en Apple Arcade.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/_0iJZN-EjZA" title="CULTURAFREAK #050" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-051.md
+++ b/_posts/2025-05-29-culturafreak-051.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #051"
+date: 2025-05-29 09:00:00 -0400
+description: "Facebook se transforma en Meta, Tesla alcanza los $1.000 por acción y vuelve a coronar a Elon Musk como el más rico del planeta, y la ISS tiene otro susto en órbita. Hablamos..."
+image: "https://img.youtube.com/vi/cP2QWMk0VxA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #051"
+resumen: "Facebook se transforma en Meta, Tesla alcanza los $1.000 por acción y vuelve a coronar a Elon Musk como el más rico del planeta, y la ISS tiene otro susto en órbita. Hablamos..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "cP2QWMk0VxA"
+youtube_url: "https://www.youtube.com/watch?v=cP2QWMk0VxA"
+---
+
+Facebook se transforma en Meta, Tesla alcanza los $1.000 por acción y vuelve a coronar a Elon Musk como el más rico del planeta, y la ISS tiene otro susto en órbita. Hablamos también del product placement descarado en Apple TV+, de por qué los links son azules, y de una IA que ha restaurado el desastre del Hindemburg en color. Además, Townscaper como recomendación jugona (aunque no es exactamente un juego), y en Apple TV+ nos metemos de lleno en la invasión alienígena con Invasion.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/cP2QWMk0VxA" title="CULTURAFREAK #051" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-052.md
+++ b/_posts/2025-05-29-culturafreak-052.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #052"
+date: 2025-05-29 09:00:00 -0400
+description: "De cómo ocultar un notch con estilo, a cómo bloquear a medio Twitter de un plumazo. Esta semana hablamos de Top Notch para MacBook Pro, de la IA de Rank Math que quiere..."
+image: "https://img.youtube.com/vi/uzz-o2WWlso/hqdefault.jpg"
+image_alt: "CULTURAFREAK #052"
+resumen: "De cómo ocultar un notch con estilo, a cómo bloquear a medio Twitter de un plumazo. Esta semana hablamos de Top Notch para MacBook Pro, de la IA de Rank Math que quiere..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "uzz-o2WWlso"
+youtube_url: "https://www.youtube.com/watch?v=uzz-o2WWlso"
+---
+
+De cómo ocultar un notch con estilo, a cómo bloquear a medio Twitter de un plumazo. Esta semana hablamos de Top Notch para MacBook Pro, de la IA de Rank Math que quiere ayudarte a escribir, del espectacular DJI Mavic 3 y de drones que caminan. Además: Netflix compra su primer estudio, Activity Awards gamifica tu vida real, y en Apple Arcade llegan los Transformers. En Apple TV+ tenemos a Tom Hanks postapocalíptico con Finch, la 3ª temporada de Dickinson, y un thriller coreano que conecta cerebros llamado Dr. Brain.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/uzz-o2WWlso" title="CULTURAFREAK #052" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-053.md
+++ b/_posts/2025-05-29-culturafreak-053.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #053"
+date: 2025-05-29 09:00:00 -0400
+description: "Semana intensa entre campañas de Black Friday y hacks millonarios. En este episodio hablamos de Apple Business Essentials, el hackeo a GoDaddy y el lanzamiento de Twitter Blue..."
+image: "https://img.youtube.com/vi/BuUxZ-UFA5U/hqdefault.jpg"
+image_alt: "CULTURAFREAK #053"
+resumen: "Semana intensa entre campañas de Black Friday y hacks millonarios. En este episodio hablamos de Apple Business Essentials, el hackeo a GoDaddy y el lanzamiento de Twitter Blue..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "BuUxZ-UFA5U"
+youtube_url: "https://www.youtube.com/watch?v=BuUxZ-UFA5U"
+---
+
+Semana intensa entre campañas de Black Friday y hacks millonarios. En este episodio hablamos de Apple Business Essentials, el hackeo a GoDaddy y el lanzamiento de Twitter Blue. Meta sigue con su obsesión por el metaverso y Niantic presenta su plataforma Lightship… pero también cierra el juego de Harry Potter. En Apple Arcade probamos Lego Star Wars: Castaway, y en Apple TV+ te recomiendo The Shrink Next Door, la serie basada en hechos reales protagonizada por Will Ferrell y Paul Rudd.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/BuUxZ-UFA5U" title="CULTURAFREAK #053" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-054.md
+++ b/_posts/2025-05-29-culturafreak-054.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #054"
+date: 2025-05-29 09:00:00 -0400
+description: "¡Volvemos tras un parón de dos meses! En este episodio te cuento cómo he rediseñado mi web personal con Jekyll y GitHub Pages, repasamos el hito bursátil de Apple y el batacazo..."
+image: "https://img.youtube.com/vi/F-fTcrC5e_Q/hqdefault.jpg"
+image_alt: "CULTURAFREAK #054"
+resumen: "¡Volvemos tras un parón de dos meses! En este episodio te cuento cómo he rediseñado mi web personal con Jekyll y GitHub Pages, repasamos el hito bursátil de Apple y el batacazo..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "F-fTcrC5e_Q"
+youtube_url: "https://www.youtube.com/watch?v=F-fTcrC5e_Q"
+---
+
+¡Volvemos tras un parón de dos meses! En este episodio te cuento cómo he rediseñado mi web personal con Jekyll y GitHub Pages, repasamos el hito bursátil de Apple y el batacazo histórico de Facebook, hablamos de la renovación de PageSpeed Insights y el nuevo rumbo de Square (ahora llamada Block). Además, te recomiendo Hidden Folks en Apple Arcade y me despido con una joya sci-fi: la última temporada de The Expanse. Ah, y sí… ya tenemos teaser de The Rings of Power.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/F-fTcrC5e_Q" title="CULTURAFREAK #054" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-055.md
+++ b/_posts/2025-05-29-culturafreak-055.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #055"
+date: 2025-05-29 09:00:00 -0400
+description: "En este episodio hablamos del fichaje estrella: el fundador de WhatsApp se convierte en CEO de Signal. Te cuento qué es el curioso proyecto W3W para mapear el mundo con solo..."
+image: "https://img.youtube.com/vi/TaplR0345Z0/hqdefault.jpg"
+image_alt: "CULTURAFREAK #055"
+resumen: "En este episodio hablamos del fichaje estrella: el fundador de WhatsApp se convierte en CEO de Signal. Te cuento qué es el curioso proyecto W3W para mapear el mundo con solo..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "TaplR0345Z0"
+youtube_url: "https://www.youtube.com/watch?v=TaplR0345Z0"
+---
+
+En este episodio hablamos del fichaje estrella: el fundador de WhatsApp se convierte en CEO de Signal. Te cuento qué es el curioso proyecto W3W para mapear el mundo con solo tres palabras, y comentamos el nuevo botón de “No me gusta” de Twitter (que no sirve para nada… todavía). Además, rumores sobre realityOS, el OS del futuro casco de Apple, y joyas digitales como Carbon para compartir código bonito y Primel, un Wordle con números primos. Cierra el episodio con un juegazo en Apple Arcade (Bloons TD6+) y una joya cinematográfica: La tragedia de Macbeth en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/TaplR0345Z0" title="CULTURAFREAK #055" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-056.md
+++ b/_posts/2025-05-29-culturafreak-056.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #056"
+date: 2025-05-29 09:00:00 -0400
+description: "Esta semana abrimos la puerta al Metaverso. Te cuento por qué todas las big tech están obsesionadas con crear su propia “realidad alternativa” y cómo los usuarios acabaremos..."
+image: "https://img.youtube.com/vi/jZEX-IautEE/hqdefault.jpg"
+image_alt: "CULTURAFREAK #056"
+resumen: "Esta semana abrimos la puerta al Metaverso. Te cuento por qué todas las big tech están obsesionadas con crear su propia “realidad alternativa” y cómo los usuarios acabaremos..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "jZEX-IautEE"
+youtube_url: "https://www.youtube.com/watch?v=jZEX-IautEE"
+---
+
+Esta semana abrimos la puerta al Metaverso. Te cuento por qué todas las big tech están obsesionadas con crear su propia “realidad alternativa” y cómo los usuarios acabaremos atrapados en una nueva guerra digital: las Reality Wars. También repasamos los peligros crecientes de WordPress, una extensión imprescindible para Safari en iOS (SafariDarkMode), y una joya de herramienta: Metatags.io, para controlar cómo se ve tu web en redes sociales. En Apple Arcade, te recomiendo HitchHiker, una historia interactiva con vibes de Twin Peaks. Y en Apple TV+, no te pierdas The Afterparty, una serie policiaca narrada desde géneros cinematográficos diferentes. Pinta brutal.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/jZEX-IautEE" title="CULTURAFREAK #056" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-057.md
+++ b/_posts/2025-05-29-culturafreak-057.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #057"
+date: 2025-05-29 09:00:00 -0400
+description: "Esta semana repasamos Peek Performance, la primera keynote de Apple en 2022, con todo lo que presentaron: nuevos colores para el iPhone, el chip M1 Ultra y el nuevo Mac Studio..."
+image: "https://img.youtube.com/vi/yLhTufurvFA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #057"
+resumen: "Esta semana repasamos Peek Performance, la primera keynote de Apple en 2022, con todo lo que presentaron: nuevos colores para el iPhone, el chip M1 Ultra y el nuevo Mac Studio..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "yLhTufurvFA"
+youtube_url: "https://www.youtube.com/watch?v=yLhTufurvFA"
+---
+
+Esta semana repasamos Peek Performance, la primera keynote de Apple en 2022, con todo lo que presentaron: nuevos colores para el iPhone, el chip M1 Ultra y el nuevo Mac Studio. También hablamos de la nueva voz no binaria de Siri, un estafador que usó QR falsos para forrarse, y webs curiosas que animan tus dibujos o generan fondos con ondas. Si te crees un experto en colores, pon a prueba tu vista con Color Matching Game. Además, recomendación cinéfila con The Batman(¡haz tu logo!) y juegazo de rol en iPad con Divinity: Original Sin 2. Y para cerrar, serie de acción recomendada: Reacher, en Amazon Prime Video.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/yLhTufurvFA" title="CULTURAFREAK #057" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-058.md
+++ b/_posts/2025-05-29-culturafreak-058.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #058"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple lanza actualizaciones importantes (iOS 15.4, macOS 12.3 y más), Substack presenta su esperada app, Shopify se mete al juego con Linkpop, y descubrimos recursos útiles..."
+image: "https://img.youtube.com/vi/yHtln14IuRA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #058"
+resumen: "Apple lanza actualizaciones importantes (iOS 15.4, macOS 12.3 y más), Substack presenta su esperada app, Shopify se mete al juego con Linkpop, y descubrimos recursos útiles..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "yHtln14IuRA"
+youtube_url: "https://www.youtube.com/watch?v=yHtln14IuRA"
+---
+
+Apple lanza actualizaciones importantes (iOS 15.4, macOS 12.3 y más), Substack presenta su esperada app, Shopify se mete al juego con Linkpop, y descubrimos recursos útiles como Achoo HTML y ZCal, una alternativa gratuita a Calendly. En la sección de juegos, Monument Valley II llega a Apple Arcade y como recomendación en series tenemos WeCrashed, el ascenso y caída de WeWork en Apple TV+ con Jared Leto y Anne Hathaway.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/yHtln14IuRA" title="CULTURAFREAK #058" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-059.md
+++ b/_posts/2025-05-29-culturafreak-059.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #059"
+date: 2025-05-29 09:00:00 -0400
+description: "Probamos Webflow, el editor web No-Code que está marcando tendencia; descubrimos ComicTrack, la app perfecta para llevar el control de tu colección de cómics; Google Domains..."
+image: "https://img.youtube.com/vi/-zopmieLpS4/hqdefault.jpg"
+image_alt: "CULTURAFREAK #059"
+resumen: "Probamos Webflow, el editor web No-Code que está marcando tendencia; descubrimos ComicTrack, la app perfecta para llevar el control de tu colección de cómics; Google Domains..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "-zopmieLpS4"
+youtube_url: "https://www.youtube.com/watch?v=-zopmieLpS4"
+---
+
+Probamos Webflow, el editor web No-Code que está marcando tendencia; descubrimos ComicTrack, la app perfecta para llevar el control de tu colección de cómics; Google Domains sale de beta tras 7 años; y PixelMe nos permite crear avatares retro en 8 bits. Además, llegan dos juegos de velocidad a Apple Arcade: Gear.Club Stradale y Sonic Dash+. Y como cierre, no te pierdas Separación (Severance) en Apple TV+, una serie inquietante con el 98% de críticas positivas en Rotten Tomatoes.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/-zopmieLpS4" title="CULTURAFREAK #059" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-060.md
+++ b/_posts/2025-05-29-culturafreak-060.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #060"
+date: 2025-05-29 09:00:00 -0400
+description: "Elon Musk quiere comprar Twitter y la polémica está servida. WhatsApp anuncia Comunidades, DuckDuckGo lanza su navegador para macOS, y descubrimos herramientas como..."
+image: "https://img.youtube.com/vi/jC9Pw8TTsJM/hqdefault.jpg"
+image_alt: "CULTURAFREAK #060"
+resumen: "Elon Musk quiere comprar Twitter y la polémica está servida. WhatsApp anuncia Comunidades, DuckDuckGo lanza su navegador para macOS, y descubrimos herramientas como..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "jC9Pw8TTsJM"
+youtube_url: "https://www.youtube.com/watch?v=jC9Pw8TTsJM"
+---
+
+Elon Musk quiere comprar Twitter y la polémica está servida. WhatsApp anuncia Comunidades, DuckDuckGo lanza su navegador para macOS, y descubrimos herramientas como Extract.pics y Smash the Walls para productividad y distracción a partes iguales. En Apple Arcade llegan Pro Snooker & Pool 2022 y Construction Simulator 2, y cerramos con el tráiler de Thor: Love & Thunder y el regreso de For All Mankind en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/jC9Pw8TTsJM" title="CULTURAFREAK #060" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-061.md
+++ b/_posts/2025-05-29-culturafreak-061.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #061"
+date: 2025-05-29 09:00:00 -0400
+description: "Esta semana hablamos del lanzamiento de Bootstrap Studio 6, el mini-dron Pixy de Snap, y la gran apuesta de Sony y LEGO por el metaverso de Epic Games. Además, navegamos por la..."
+image: "https://img.youtube.com/vi/HB-MI0qVt1M/hqdefault.jpg"
+image_alt: "CULTURAFREAK #061"
+resumen: "Esta semana hablamos del lanzamiento de Bootstrap Studio 6, el mini-dron Pixy de Snap, y la gran apuesta de Sony y LEGO por el metaverso de Epic Games. Además, navegamos por la..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "HB-MI0qVt1M"
+youtube_url: "https://www.youtube.com/watch?v=HB-MI0qVt1M"
+---
+
+Esta semana hablamos del lanzamiento de Bootstrap Studio 6, el mini-dron Pixy de Snap, y la gran apuesta de Sony y LEGO por el metaverso de Epic Games. Además, navegamos por la web más frustrante del mundo, redimensionamos imágenes con IA, y nos entretenemos dibujando icebergs. En Apple Arcade llega Goat Simulator+, y en Apple TV+ destacamos They Call Me Magic. Cerramos con una nueva vuelta de tuerca en la novela de Elon Musk y Twitter.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/HB-MI0qVt1M" title="CULTURAFREAK #061" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-062.md
+++ b/_posts/2025-05-29-culturafreak-062.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #062"
+date: 2025-05-29 09:00:00 -0400
+description: "Resumen exprés pero cargado de novedades: Apple anuncia la WWDC 2022, Word sufre una grave vulnerabilidad, y Amazon por fin acepta EPUB en Kindle. Además, Google se mete de..."
+image: "https://img.youtube.com/vi/ekMiSKQzTfU/hqdefault.jpg"
+image_alt: "CULTURAFREAK #062"
+resumen: "Resumen exprés pero cargado de novedades: Apple anuncia la WWDC 2022, Word sufre una grave vulnerabilidad, y Amazon por fin acepta EPUB en Kindle. Además, Google se mete de..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "ekMiSKQzTfU"
+youtube_url: "https://www.youtube.com/watch?v=ekMiSKQzTfU"
+---
+
+Resumen exprés pero cargado de novedades: Apple anuncia la WWDC 2022, Word sufre una grave vulnerabilidad, y Amazon por fin acepta EPUB en Kindle. Además, Google se mete de lleno en la AR/VR con su Proyecto Iris, mientras los Cazafantasmas llegan en realidad virtual. También hablamos de DALL·E 2, la IA que convierte texto en imágenes, descubrimos el bundle de apps Setapp, repasamos la app de diario Day One, y cerramos con los mejores mandos para Apple Arcade y el documental Planeta Prehistórico en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/ekMiSKQzTfU" title="CULTURAFREAK #062" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-063.md
+++ b/_posts/2025-05-29-culturafreak-063.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #063"
+date: 2025-05-29 09:00:00 -0400
+description: "Semana intensa tras la WWDC 2022 de Apple: repasamos todas las novedades de iOS 16, iPadOS 16, macOS Ventura y el rediseñado MacBook Air con chip M2. Además, GitHub anuncia el..."
+image: "https://img.youtube.com/vi/yFGR3R5rZyw/hqdefault.jpg"
+image_alt: "CULTURAFREAK #063"
+resumen: "Semana intensa tras la WWDC 2022 de Apple: repasamos todas las novedades de iOS 16, iPadOS 16, macOS Ventura y el rediseñado MacBook Air con chip M2. Además, GitHub anuncia el..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "yFGR3R5rZyw"
+youtube_url: "https://www.youtube.com/watch?v=yFGR3R5rZyw"
+---
+
+Semana intensa tras la WWDC 2022 de Apple: repasamos todas las novedades de iOS 16, iPadOS 16, macOS Ventura y el rediseñado MacBook Air con chip M2. Además, GitHub anuncia el fin de Atom, llega Chrome OS Flex para revivir ordenadores antiguos, y descubrimos Shrink.Media para comprimir imágenes fácilmente. En videojuegos, aterriza Diablo Immortal (con advertencia de micropagos), y en Apple TV+ se estrena la esperada tercera temporada de For All Mankind.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/yFGR3R5rZyw" title="CULTURAFREAK #063" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-064.md
+++ b/_posts/2025-05-29-culturafreak-064.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #064"
+date: 2025-05-29 09:00:00 -0400
+description: "Readdle lanza su app Calendars para macOS, Logitech actualiza su ratón estrella con el MX Master 3S y descubrimos Emojitracker, una joya para freaks de las estadísticas..."
+image: "https://img.youtube.com/vi/cUFyD-Og8q0/hqdefault.jpg"
+image_alt: "CULTURAFREAK #064"
+resumen: "Readdle lanza su app Calendars para macOS, Logitech actualiza su ratón estrella con el MX Master 3S y descubrimos Emojitracker, una joya para freaks de las estadísticas..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "cUFyD-Og8q0"
+youtube_url: "https://www.youtube.com/watch?v=cUFyD-Og8q0"
+---
+
+Readdle lanza su app Calendars para macOS, Logitech actualiza su ratón estrella con el MX Master 3S y descubrimos Emojitracker, una joya para freaks de las estadísticas. Hablamos también del futuro del Metaverso según Zuckerberg, el apoyo de 1Password al estándar FIDO, y el nuevo juego HEROish en Apple Arcade. Cerramos con novedades de Apple TV+, incluyendo Trying y Mythic Quest, y sus 52 nominaciones a los Emmy.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/cUFyD-Og8q0" title="CULTURAFREAK #064" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-065.md
+++ b/_posts/2025-05-29-culturafreak-065.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #065"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple rompe récords financieros una vez más en su Q3 2022, mientras Meta sube el precio de las Quest 2 en plena fiebre del Metaverso. Hablamos de una nueva extensión para..."
+image: "https://img.youtube.com/vi/dvasAA9f4bY/hqdefault.jpg"
+image_alt: "CULTURAFREAK #065"
+resumen: "Apple rompe récords financieros una vez más en su Q3 2022, mientras Meta sube el precio de las Quest 2 en plena fiebre del Metaverso. Hablamos de una nueva extensión para..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "dvasAA9f4bY"
+youtube_url: "https://www.youtube.com/watch?v=dvasAA9f4bY"
+---
+
+Apple rompe récords financieros una vez más en su Q3 2022, mientras Meta sube el precio de las Quest 2 en plena fiebre del Metaverso. Hablamos de una nueva extensión para reforzar la seguridad en WhatsApp Web, te comparto un recurso con miles de logos vectorizados y te enseño mi proyecto exprés: una web con la cronología de Marvel Studios creada con Carrd. Además, Sony lanza Backbone One - PlayStation Edition para jugar desde el iPhone y cerramos con el estreno de Luck en Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/dvasAA9f4bY" title="CULTURAFREAK #065" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-066.md
+++ b/_posts/2025-05-29-culturafreak-066.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #066"
+date: 2025-05-29 09:00:00 -0400
+description: "¡He vuelto! Tras casi tres meses de silencio, te traigo una edición cargada de noticias tech, gadgets y curiosidades freak. Hablamos del enésimo drama de Elon Musk con Twitter..."
+image: "https://img.youtube.com/vi/rfEaL08AMsA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #066"
+resumen: "¡He vuelto! Tras casi tres meses de silencio, te traigo una edición cargada de noticias tech, gadgets y curiosidades freak. Hablamos del enésimo drama de Elon Musk con Twitter..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "rfEaL08AMsA"
+youtube_url: "https://www.youtube.com/watch?v=rfEaL08AMsA"
+---
+
+¡He vuelto! Tras casi tres meses de silencio, te traigo una edición cargada de noticias tech, gadgets y curiosidades freak. Hablamos del enésimo drama de Elon Musk con Twitter, del acuerdo de Apple con la Super Bowl, del nuevo Kindle Scribe con lápiz incluido y de un póster cinéfilo con las 250 mejores pelis según IMDb. También te dejo un par de recursos de diseño y datos históricos sobre webs más visitadas (spoiler: GeoCities aparece). Y como siempre, cerramos con lo mejor de Apple Arcade y Apple TV+.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/rfEaL08AMsA" title="CULTURAFREAK #066" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-067.md
+++ b/_posts/2025-05-29-culturafreak-067.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #067"
+date: 2025-05-29 09:00:00 -0400
+description: "Esta semana te traigo una buena dosis de noticias tech y cultura freak: la NASA lanza su supercohete SLS para la misión Artemis, iCloud Web estrena rediseño, y ya están a la..."
+image: "https://img.youtube.com/vi/QHOgyKxdJII/hqdefault.jpg"
+image_alt: "CULTURAFREAK #067"
+resumen: "Esta semana te traigo una buena dosis de noticias tech y cultura freak: la NASA lanza su supercohete SLS para la misión Artemis, iCloud Web estrena rediseño, y ya están a la..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "QHOgyKxdJII"
+youtube_url: "https://www.youtube.com/watch?v=QHOgyKxdJII"
+---
+
+Esta semana te traigo una buena dosis de noticias tech y cultura freak: la NASA lanza su supercohete SLS para la misión Artemis, iCloud Web estrena rediseño, y ya están a la venta las Meta Quest Pro con su juego estrella: Iron Man VR. También te recomiendo Fontjoy si diseñas con letras, y Playphrase si eres cinéfilo y te gusta buscar frases de pelis. Cerramos con un Football Manager 2023 para Apple Arcade (sí, tipo PC Fútbol) y el regreso de Mythic Quest a Apple TV+. ¡Dale al play!
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/QHOgyKxdJII" title="CULTURAFREAK #067" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-068.md
+++ b/_posts/2025-05-29-culturafreak-068.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #068"
+date: 2025-05-29 09:00:00 -0400
+description: "¡CULTURAFREAK está de vuelta! En esta nueva etapa, más personal y cercana, te cuento qué he estado haciendo estos meses, desde mis artículos recientes sobre productividad..."
+image: "https://img.youtube.com/vi/zWRCphMkanE/hqdefault.jpg"
+image_alt: "CULTURAFREAK #068"
+resumen: "¡CULTURAFREAK está de vuelta! En esta nueva etapa, más personal y cercana, te cuento qué he estado haciendo estos meses, desde mis artículos recientes sobre productividad..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "zWRCphMkanE"
+youtube_url: "https://www.youtube.com/watch?v=zWRCphMkanE"
+---
+
+¡CULTURAFREAK está de vuelta! En esta nueva etapa, más personal y cercana, te cuento qué he estado haciendo estos meses, desde mis artículos recientes sobre productividad, salud y series, hasta mi salto de Twitter a Mastodon. También te traigo recursos curiosos como Blush Design y Abbrevia.me, el regreso de Ted Lasso, el estreno de Tetris en Apple TV+, y un juegazo: Lifeline+ en Apple Arcade. Vuelve el café, las risas y las frikadas. ¡Dale al play!
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/zWRCphMkanE" title="CULTURAFREAK #068" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-069.md
+++ b/_posts/2025-05-29-culturafreak-069.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #069"
+date: 2025-05-29 09:00:00 -0400
+description: "Hoy me pongo el gorro de gamer y te cuento cómo he redescubierto mi pasión por los RPGs gracias a la Switch y a joyas como Zelda: Breath of the Wild y Persona 5. Además..."
+image: "https://img.youtube.com/vi/RI2yBP45IeA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #069"
+resumen: "Hoy me pongo el gorro de gamer y te cuento cómo he redescubierto mi pasión por los RPGs gracias a la Switch y a joyas como Zelda: Breath of the Wild y Persona 5. Además..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "RI2yBP45IeA"
+youtube_url: "https://www.youtube.com/watch?v=RI2yBP45IeA"
+---
+
+Hoy me pongo el gorro de gamer y te cuento cómo he redescubierto mi pasión por los RPGs gracias a la Switch y a joyas como Zelda: Breath of the Wild y Persona 5. Además, hablamos del lanzamiento de GPT-4, los rumores de que Meta prepara su propio “Twitter”, y te traigo recursos top como Loom, Brickit y GameTrack. Cerramos con un juegazo (Ocean Horn 2) y una serie imprescindible: Shrinking en Apple TV+. Dale al play y acompáñame.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/RI2yBP45IeA" title="CULTURAFREAK #069" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-071.md
+++ b/_posts/2025-05-29-culturafreak-071.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #071"
+date: 2025-05-29 09:00:00 -0400
+description: "¡Volvemos en 2024! Te cuento con qué equipo tecnológico empiezo el año (spoiler: minimalismo, M2 y muchos EarPods), y presento RECURSOS by AJRA, un nuevo proyecto con..."
+image: "https://img.youtube.com/vi/eokqAHtBiMo/hqdefault.jpg"
+image_alt: "CULTURAFREAK #071"
+resumen: "¡Volvemos en 2024! Te cuento con qué equipo tecnológico empiezo el año (spoiler: minimalismo, M2 y muchos EarPods), y presento RECURSOS by AJRA, un nuevo proyecto con..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "eokqAHtBiMo"
+youtube_url: "https://www.youtube.com/watch?v=eokqAHtBiMo"
+---
+
+¡Volvemos en 2024! Te cuento con qué equipo tecnológico empiezo el año (spoiler: minimalismo, M2 y muchos EarPods), y presento RECURSOS by AJRA, un nuevo proyecto con herramientas No-Code para crear sin saber programar. Además, repasamos lanzamientos como las Apple Vision Pro, la GPT Store de OpenAI, el Galaxy Unpacked y la curiosa funda-teclado Clicks. Como siempre, cerramos con un recurso útil (Convertio) y algunos eventos destacados de la semana. Tecnología, gadgets y cultura freak para comenzar el año con todo.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/eokqAHtBiMo" title="CULTURAFREAK #071" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-072.md
+++ b/_posts/2025-05-29-culturafreak-072.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #072"
+date: 2025-05-29 09:00:00 -0400
+description: "Apple pone fecha a la WWDC24, Duolingo despide al 10% y lo reemplaza con IA, Meta calienta hogares con sus servidores y Stardew Valley se actualiza gratis. Además, Threads se..."
+image: "https://img.youtube.com/vi/Alx0CYZzkiA/hqdefault.jpg"
+image_alt: "CULTURAFREAK #072"
+resumen: "Apple pone fecha a la WWDC24, Duolingo despide al 10% y lo reemplaza con IA, Meta calienta hogares con sus servidores y Stardew Valley se actualiza gratis. Además, Threads se..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Alx0CYZzkiA"
+youtube_url: "https://www.youtube.com/watch?v=Alx0CYZzkiA"
+---
+
+Apple pone fecha a la WWDC24, Duolingo despide al 10% y lo reemplaza con IA, Meta calienta hogares con sus servidores y Stardew Valley se actualiza gratis. Además, Threads se une al Fediverso y descubrimos ARC, un navegador que puede que te cambie la vida. Cerramos con trailers potentes: The Acolyte, Fallout, Bad Boys 4 y Civil War. Cultura digital, entretenimiento y tecnología al estilo AJRA.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Alx0CYZzkiA" title="CULTURAFREAK #072" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-073.md
+++ b/_posts/2025-05-29-culturafreak-073.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #073"
+date: 2025-05-29 09:00:00 -0400
+description: "WordPress 6.5 ya está aquí, Apple activa ‘Spatial Persona’ en visionOS, y ahora podrás emular tus juegos retro desde la App Store. Además, Sam Altman, Jony Ive y Laurene Powell..."
+image: "https://img.youtube.com/vi/o7bZIPrCRF0/hqdefault.jpg"
+image_alt: "CULTURAFREAK #073"
+resumen: "WordPress 6.5 ya está aquí, Apple activa ‘Spatial Persona’ en visionOS, y ahora podrás emular tus juegos retro desde la App Store. Además, Sam Altman, Jony Ive y Laurene Powell..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "o7bZIPrCRF0"
+youtube_url: "https://www.youtube.com/watch?v=o7bZIPrCRF0"
+---
+
+WordPress 6.5 ya está aquí, Apple activa ‘Spatial Persona’ en visionOS, y ahora podrás emular tus juegos retro desde la App Store. Además, Sam Altman, Jony Ive y Laurene Powell Jobs se alían para un nuevo hardware de IA. En recursos, LM Studio te permite correr tus propios modelos en local. Y en cine: Fallout, Godzilla x Kong y Civil War llegan esta semana, mientras Bambi se convierte en máquina de matar y My Hero Academia lanza tráiler de la temporada 7.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/o7bZIPrCRF0" title="CULTURAFREAK #073" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-074.md
+++ b/_posts/2025-05-29-culturafreak-074.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #074"
+date: 2025-05-29 09:00:00 -0400
+description: "Celebramos los 20 años de Ubuntu, Meta actualiza sus gafas Quest y se prepara para lanzar LLaMA 3. Además, Microsoft presenta IA para uso militar y surgen rumores del chip M4..."
+image: "https://img.youtube.com/vi/pz4a0DFt79A/hqdefault.jpg"
+image_alt: "CULTURAFREAK #074"
+resumen: "Celebramos los 20 años de Ubuntu, Meta actualiza sus gafas Quest y se prepara para lanzar LLaMA 3. Además, Microsoft presenta IA para uso militar y surgen rumores del chip M4..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "pz4a0DFt79A"
+youtube_url: "https://www.youtube.com/watch?v=pz4a0DFt79A"
+---
+
+Celebramos los 20 años de Ubuntu, Meta actualiza sus gafas Quest y se prepara para lanzar LLaMA 3. Además, Microsoft presenta IA para uso militar y surgen rumores del chip M4 de Apple. En recursos, destacamos a Claude, una alternativa potente y accesible a ChatGPT. Y en cine y series: llegan los tráilers de Joker: Folie à Deux, Maxxxine y Dark Matter. También repasamos los próximos estrenos: Rebel Moon - Parte Dos, Abigail y el GP de China.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/pz4a0DFt79A" title="CULTURAFREAK #074" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-075.md
+++ b/_posts/2025-05-29-culturafreak-075.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #075"
+date: 2025-05-29 09:00:00 -0400
+description: "Meta lanza oficialmente LLaMA 3, el emulador Delta aterriza en iOS, y YouTube VR mejora su experiencia en Meta Quest 3. Además, Tesla despide al 10% de su plantilla y Musk..."
+image: "https://img.youtube.com/vi/sECSBElGd8Q/hqdefault.jpg"
+image_alt: "CULTURAFREAK #075"
+resumen: "Meta lanza oficialmente LLaMA 3, el emulador Delta aterriza en iOS, y YouTube VR mejora su experiencia en Meta Quest 3. Además, Tesla despide al 10% de su plantilla y Musk..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "sECSBElGd8Q"
+youtube_url: "https://www.youtube.com/watch?v=sECSBElGd8Q"
+---
+
+Meta lanza oficialmente LLaMA 3, el emulador Delta aterriza en iOS, y YouTube VR mejora su experiencia en Meta Quest 3. Además, Tesla despide al 10% de su plantilla y Musk vuelve a la carga con ideas para monetizar Twitter. En recursos, destacamos ElevenLabs, la mejor plataforma para clonación de voz. Y en cine y TV: tráileres de Transformers One, Alien Romulus y My Adventures with Superman, junto a los estrenos de Challengers, El Caso Asunta y más.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/sECSBElGd8Q" title="CULTURAFREAK #075" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-076.md
+++ b/_posts/2025-05-29-culturafreak-076.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #076"
+date: 2025-05-29 09:00:00 -0400
+description: "Meta abre su sistema operativo Meta Horizon OS a otras marcas, Apple prepara nuevo evento, y las gafas Ray-Ban de Meta se vuelven multimodales. Además, WhatsApp añade PassKey..."
+image: "https://img.youtube.com/vi/NzwaJrfHjks/hqdefault.jpg"
+image_alt: "CULTURAFREAK #076"
+resumen: "Meta abre su sistema operativo Meta Horizon OS a otras marcas, Apple prepara nuevo evento, y las gafas Ray-Ban de Meta se vuelven multimodales. Además, WhatsApp añade PassKey..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "NzwaJrfHjks"
+youtube_url: "https://www.youtube.com/watch?v=NzwaJrfHjks"
+---
+
+Meta abre su sistema operativo Meta Horizon OS a otras marcas, Apple prepara nuevo evento, y las gafas Ray-Ban de Meta se vuelven multimodales. Además, WhatsApp añade PassKey en iPhone y llega la nueva Insta360 X4. Esta semana destacamos Craft como recurso de organización, y repasamos tráilers de Deadpool 3, Mufasa y Atlas, junto a estrenos clave como The Fall Guy, Godzilla Minus One y más.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/NzwaJrfHjks" title="CULTURAFREAK #076" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-29-culturafreak-077.md
+++ b/_posts/2025-05-29-culturafreak-077.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #077"
+date: 2025-05-29 09:00:00 -0400
+description: "Repasamos los lanzamientos tech de la semana: el nuevo ChatGPT o1 con habilidades de razonamiento, el iPhone 16 y novedades de Apple, la app de Perplexity para Mac, y las..."
+image: "https://img.youtube.com/vi/07Gkt_3RN_g/hqdefault.jpg"
+image_alt: "CULTURAFREAK #077"
+resumen: "Repasamos los lanzamientos tech de la semana: el nuevo ChatGPT o1 con habilidades de razonamiento, el iPhone 16 y novedades de Apple, la app de Perplexity para Mac, y las..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "07Gkt_3RN_g"
+youtube_url: "https://www.youtube.com/watch?v=07Gkt_3RN_g"
+---
+
+Repasamos los lanzamientos tech de la semana: el nuevo ChatGPT o1 con habilidades de razonamiento, el iPhone 16 y novedades de Apple, la app de Perplexity para Mac, y las nuevas gafas de realidad aumentada de Meta. Además, v0.dev como herramienta IA para programar sin saber código, y los tráilers de Nosferatu y Juror #2, lo nuevo de Clint Eastwood.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/07Gkt_3RN_g" title="CULTURAFREAK #077" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-05-30-culturafreak-070.md
+++ b/_posts/2025-05-30-culturafreak-070.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "CULTURAFREAK #070"
+date: 2025-05-30 09:00:00 -0400
+description: "En este episodio me pongo personal y te cuento cómo he perdido 13 kilos (sin magia, solo con apps y constancia). Te hablo de mi rutina con Apple Watch, Lose It!, Gentle Streak..."
+image: "https://img.youtube.com/vi/h60-4Z5roWM/hqdefault.jpg"
+image_alt: "CULTURAFREAK #070"
+resumen: "En este episodio me pongo personal y te cuento cómo he perdido 13 kilos (sin magia, solo con apps y constancia). Te hablo de mi rutina con Apple Watch, Lose It!, Gentle Streak..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "h60-4Z5roWM"
+youtube_url: "https://www.youtube.com/watch?v=h60-4Z5roWM"
+---
+
+En este episodio me pongo personal y te cuento cómo he perdido 13 kilos (sin magia, solo con apps y constancia). Te hablo de mi rutina con Apple Watch, Lose It!, Gentle Streak, Supernatural en VR y más. Además, comparto un atajo que hice para trackear agua y cafeína, una curiosidad lunar, la herramienta CSS Peeper para diseñadores y, como siempre, nuestras secciones de Apple Arcade (Clue: The Classic Mystery Game+) y Apple TV+ (Hello Tomorrow). Salud, gadgets y misterio, todo en uno.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/h60-4Z5roWM" title="CULTURAFREAK #070" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-02-flux-1-kontext-nuevo-modelo-de-bfl.md
+++ b/_posts/2025-06-02-flux-1-kontext-nuevo-modelo-de-bfl.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: "FLUX.1 Kontext: nuevo modelo de BFL"
+date: 2025-06-02 09:00:00 -0400
+description: "Kontext y Playground son los dos primeros módulos de FLUX.1, la nueva interfaz experimental de la startup BFL.AI."
+image: "https://img.youtube.com/vi/MZidYyMDhTM/hqdefault.jpg"
+image_alt: "FLUX.1 Kontext: nuevo modelo de BFL"
+resumen: "Kontext y Playground son los dos primeros módulos de FLUX.1, la nueva interfaz experimental de la startup BFL.AI."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "MZidYyMDhTM"
+youtube_url: "https://www.youtube.com/watch?v=MZidYyMDhTM"
+---
+
+Kontext y Playground son los dos primeros módulos de FLUX.1, la nueva interfaz experimental de la startup BFL.AI. 
+
+En menos de 5 minutos os contamos lo esencial para que entiendas si esto es humo o si estamos ante un nuevo paradigma en la forma en que usamos la IA.
+
+
+🎧 Disponible en Spotify, Apple Podcast y YouTube.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/MZidYyMDhTM" title="FLUX.1 Kontext: nuevo modelo de BFL" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-02-jony-ive-y-sam-altman-el-futuro-de-la-ia.md
+++ b/_posts/2025-06-02-jony-ive-y-sam-altman-el-futuro-de-la-ia.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title: "Jony Ive & Sam Altman. El futuro de la iA"
+date: 2025-06-02 09:00:00 -0400
+description: "En este episodio, exploramos la trascendental unión entre el visionario diseñador Jony Ive, conocido por su trabajo en Apple, y el líder en inteligencia artificial, OpenAI."
+image: "https://img.youtube.com/vi/pCdoP024rQo/hqdefault.jpg"
+image_alt: "Jony Ive & Sam Altman. El futuro de la iA"
+resumen: "En este episodio, exploramos la trascendental unión entre el visionario diseñador Jony Ive, conocido por su trabajo en Apple, y el líder en inteligencia artificial, OpenAI."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "pCdoP024rQo"
+youtube_url: "https://www.youtube.com/watch?v=pCdoP024rQo"
+---
+
+En este episodio, exploramos la trascendental unión entre el visionario diseñador Jony Ive, conocido por su trabajo en Apple, y el líder en inteligencia artificial, OpenAI. 
+
+
+OpenAI ha adquirido la empresa de hardware de Ive, io, en un acuerdo valorado en casi $6.5 mil millones. Esta adquisición significa que Ive y su firma de diseño, LoveFrom, ahora liderarán el control creativo y de diseño para todos los proyectos de OpenAI, incluyendo futuras versiones de ChatGPT y nuevas aplicaciones. 
+
+
+La colaboración, que ya lleva dos años gestándose entre Ive y el CEO de OpenAI, Sam Altman, se centra en desarrollar una nueva generación de dispositivos de consumo impulsados por IA. 
+
+
+
+
+
+
+¿Es el futuro… o una fantasía millonaria?
+
+
+
+
+
+
+🎧 Escúchalo ya en Spotify, Apple Podcast y YouTube.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/pCdoP024rQo" title="Jony Ive &amp; Sam Altman. El futuro de la iA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-02-perplexity-labs-explora-crea-repiensa.md
+++ b/_posts/2025-06-02-perplexity-labs-explora-crea-repiensa.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Perplexity Labs: Explora. Crea. Repiensa."
+date: 2025-06-02 09:00:00 -0400
+description: "Perplexity da un paso más allá como buscador con el lanzamiento de Perplexity Labs, una plataforma pensada para explorar el futuro de la inteligencia artificial aplicada al..."
+image: "https://img.youtube.com/vi/hyGovAVpb_U/hqdefault.jpg"
+image_alt: "Perplexity Labs: Explora. Crea. Repiensa."
+resumen: "Perplexity da un paso más allá como buscador con el lanzamiento de Perplexity Labs, una plataforma pensada para explorar el futuro de la inteligencia artificial aplicada al..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "hyGovAVpb_U"
+youtube_url: "https://www.youtube.com/watch?v=hyGovAVpb_U"
+---
+
+Perplexity da un paso más allá como buscador con el lanzamiento de Perplexity Labs, una plataforma pensada para explorar el futuro de la inteligencia artificial aplicada al conocimiento. 
+
+
+En este episodio repasamos qué es Labs, qué herramientas ofrece y por qué este movimiento puede marcar un antes y un después en la carrera por liderar el espacio IA.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/hyGovAVpb_U" title="Perplexity Labs: Explora. Crea. Repiensa." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-04-codex-para-todos-openai-libera-su-agente-de-programacion-a-usuarios-plus.md
+++ b/_posts/2025-06-04-codex-para-todos-openai-libera-su-agente-de-programacion-a-usuarios-plus.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: "Codex para todos: OpenAI libera su agente de programación a usuarios Plus"
+date: 2025-06-04 09:00:00 -0400
+description: "OpenAI ha liberado Codex para todos los usuarios con el plan Plus de ChatGPT."
+image: "https://img.youtube.com/vi/g_u4X0337Vk/hqdefault.jpg"
+image_alt: "Codex para todos: OpenAI libera su agente de programación a usuarios Plus"
+resumen: "OpenAI ha liberado Codex para todos los usuarios con el plan Plus de ChatGPT."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "g_u4X0337Vk"
+youtube_url: "https://www.youtube.com/watch?v=g_u4X0337Vk"
+---
+
+OpenAI ha liberado Codex para todos los usuarios con el plan Plus de ChatGPT. 
+
+
+
+
+
+
+En este episodio te cuento qué es, cómo funciona y por qué este movimiento puede cambiar la forma en que programamos con IA.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/g_u4X0337Vk" title="Codex para todos: OpenAI libera su agente de programación a usuarios Plus" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-05-state-of-play-tu-racion-freak-de-videojuegos.md
+++ b/_posts/2025-06-05-state-of-play-tu-racion-freak-de-videojuegos.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: "State of Play: Tu ración freak de videojuegos"
+date: 2025-06-05 09:00:00 -0400
+description: "Sony volvió con su clásico State of Play y en esta edición repasamos lo mejor, lo peor y lo más hypeado del evento."
+image: "https://img.youtube.com/vi/Jrue_Wq_-iI/hqdefault.jpg"
+image_alt: "State of Play: Tu ración freak de videojuegos"
+resumen: "Sony volvió con su clásico State of Play y en esta edición repasamos lo mejor, lo peor y lo más hypeado del evento."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Jrue_Wq_-iI"
+youtube_url: "https://www.youtube.com/watch?v=Jrue_Wq_-iI"
+---
+
+Sony volvió con su clásico State of Play y en esta edición repasamos lo mejor, lo peor y lo más hypeado del evento.
+
+
+Trailers, sorpresas, ausencias dolorosas y esa dosis justa de ilusión gamer que nos alimenta entre lanzamientos.
+
+
+
+
+
+
+Prepárate para tu ración freak de videojuegos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Jrue_Wq_-iI" title="State of Play: Tu ración freak de videojuegos" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-06-immersed-tu-espacio-de-trabajo-en-vr.md
+++ b/_posts/2025-06-06-immersed-tu-espacio-de-trabajo-en-vr.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: "Immersed: Tu espacio de trabajo en VR"
+date: 2025-06-06 09:00:00 -0400
+description: "¿Y si pudieras tener múltiples monitores, sin cables, en cualquier lugar del mundo?"
+image: "https://img.youtube.com/vi/oNOa8Ky6hVM/hqdefault.jpg"
+image_alt: "Immersed: Tu espacio de trabajo en VR"
+resumen: "¿Y si pudieras tener múltiples monitores, sin cables, en cualquier lugar del mundo?"
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "oNOa8Ky6hVM"
+youtube_url: "https://www.youtube.com/watch?v=oNOa8Ky6hVM"
+---
+
+¿Y si pudieras tener múltiples monitores, sin cables, en cualquier lugar del mundo? 
+
+
+En este episodio exploramos Immersed, una app que convierte tu visor de realidad virtual en un setup de productividad sin límites.
+
+
+¿Vale la pena?
+
+
+¿Es el futuro del trabajo remoto o solo una curiosidad techie? 
+
+
+Ponte las gafas (virtuales) y acompáñanos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/oNOa8Ky6hVM" title="Immersed: Tu espacio de trabajo en VR" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-09-xbox-rog-ally-la-portatil-definitiva-para-game-pass.md
+++ b/_posts/2025-06-09-xbox-rog-ally-la-portatil-definitiva-para-game-pass.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Xbox ROG Ally: La portátil definitiva para Game Pass"
+date: 2025-06-09 09:00:00 -0400
+description: "Microsoft y ASUS se han aliado para lanzar una nueva bestia portátil: la Xbox ROG Ally."
+image: "https://img.youtube.com/vi/5CeFBe8MwnQ/hqdefault.jpg"
+image_alt: "Xbox ROG Ally: La portátil definitiva para Game Pass"
+resumen: "Microsoft y ASUS se han aliado para lanzar una nueva bestia portátil: la Xbox ROG Ally."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "5CeFBe8MwnQ"
+youtube_url: "https://www.youtube.com/watch?v=5CeFBe8MwnQ"
+---
+
+Microsoft y ASUS se han aliado para lanzar una nueva bestia portátil: la Xbox ROG Ally. 
+
+
+En este episodio exploramos sus dos modelos, el potencial del chip Z2 Extreme, su integración con Game Pass, y si realmente puede destronar a la Steam Deck.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/5CeFBe8MwnQ" title="Xbox ROG Ally: La portátil definitiva para Game Pass" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-11-liquid-glass-el-nuevo-lenguaje-de-diseno-de-apple.md
+++ b/_posts/2025-06-11-liquid-glass-el-nuevo-lenguaje-de-diseno-de-apple.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Liquid Glass: el nuevo lenguaje de diseño de Apple"
+date: 2025-06-11 09:00:00 -0400
+description: "Apple presenta Liquid Glass, su nuevo lenguaje de diseño para iOS, iPadOS y visionOS."
+image: "https://img.youtube.com/vi/PVTicSbvXzs/hqdefault.jpg"
+image_alt: "Liquid Glass: el nuevo lenguaje de diseño de Apple"
+resumen: "Apple presenta Liquid Glass, su nuevo lenguaje de diseño para iOS, iPadOS y visionOS."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "PVTicSbvXzs"
+youtube_url: "https://www.youtube.com/watch?v=PVTicSbvXzs"
+---
+
+Apple presenta Liquid Glass, su nuevo lenguaje de diseño para iOS, iPadOS y visionOS. 
+
+
+Transiciones fluidas, profundidad dinámica y una estética translúcida que redefine cómo interactuamos con nuestros dispositivos. 
+
+
+¿Es solo una capa bonita o un cambio de paradigma en la experiencia Apple?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/PVTicSbvXzs" title="Liquid Glass: el nuevo lenguaje de diseño de Apple" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-16-la-ilusion-del-pensamiento-el-paper-de-apple-sobre-ia.md
+++ b/_posts/2025-06-16-la-ilusion-del-pensamiento-el-paper-de-apple-sobre-ia.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "La Ilusión del Pensamiento: el paper de Apple sobre IA"
+date: 2025-06-16 09:00:00 -0400
+description: "Apple publica un paper titulado “La Ilusión del Pensamiento”, donde analiza los límites actuales de los modelos de lenguaje y su aparente capacidad de razonar."
+image: "https://img.youtube.com/vi/kGyPzaLTrts/hqdefault.jpg"
+image_alt: "La Ilusión del Pensamiento: el paper de Apple sobre IA"
+resumen: "Apple publica un paper titulado “La Ilusión del Pensamiento”, donde analiza los límites actuales de los modelos de lenguaje y su aparente capacidad de razonar."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "kGyPzaLTrts"
+youtube_url: "https://www.youtube.com/watch?v=kGyPzaLTrts"
+---
+
+Apple publica un paper titulado “La Ilusión del Pensamiento”, donde analiza los límites actuales de los modelos de lenguaje y su aparente capacidad de razonar. 
+
+
+¿Piensan realmente las IA o solo lo aparentan? 
+
+
+Exploramos el enfoque de Apple frente a competidores como OpenAI y Google, y qué pistas deja sobre el futuro de Siri.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/kGyPzaLTrts" title="La Ilusión del Pensamiento: el paper de Apple sobre IA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-17-adobe-firefly-en-tu-bolsillo-la-ia-creativa-de-adobe-llega-al-movil.md
+++ b/_posts/2025-06-17-adobe-firefly-en-tu-bolsillo-la-ia-creativa-de-adobe-llega-al-movil.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "Adobe Firefly en tu bolsillo: la IA creativa de Adobe llega al móvil."
+date: 2025-06-17 09:00:00 -0400
+description: "Adobe lleva su inteligencia artificial generativa a iOS y Android con Firefly Mobile."
+image: "https://img.youtube.com/vi/pg1LopYb9ac/hqdefault.jpg"
+image_alt: "Adobe Firefly en tu bolsillo: la IA creativa de Adobe llega al móvil."
+resumen: "Adobe lleva su inteligencia artificial generativa a iOS y Android con Firefly Mobile."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "pg1LopYb9ac"
+youtube_url: "https://www.youtube.com/watch?v=pg1LopYb9ac"
+---
+
+Adobe lleva su inteligencia artificial generativa a iOS y Android con Firefly Mobile. 
+
+
+Ahora puedes crear imágenes, editar texto y aplicar efectos visuales con solo unos toques desde el móvil.
+
+
+ ¿Revolución creativa o juguete limitado? 
+
+
+Te contamos qué ofrece, cómo se integra con Creative Cloud y qué impacto puede tener en el futuro del diseño móvil.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/pg1LopYb9ac" title="Adobe Firefly en tu bolsillo: la IA creativa de Adobe llega al móvil." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-19-midjourney-v1-de-la-imagen-al-movimiento.md
+++ b/_posts/2025-06-19-midjourney-v1-de-la-imagen-al-movimiento.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Midjourney V1: de la imagen al movimiento."
+date: 2025-06-19 09:00:00 -0400
+description: "Midjourney da el salto al vídeo con su modelo Video V1."
+image: "https://img.youtube.com/vi/NffJ1n6eEeg/hqdefault.jpg"
+image_alt: "Midjourney V1: de la imagen al movimiento."
+resumen: "Midjourney da el salto al vídeo con su modelo Video V1."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "NffJ1n6eEeg"
+youtube_url: "https://www.youtube.com/watch?v=NffJ1n6eEeg"
+---
+
+Midjourney da el salto al vídeo con su modelo Video V1. 
+
+
+En este episodio exploramos sus primeras pruebas, el potencial creativo que ofrece y cómo compite con otras IA de generación de vídeo como Sora o VEO3. 
+
+
+¿Es este el inicio de una nueva era visual o solo un teaser de lo que está por venir?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/NffJ1n6eEeg" title="Midjourney V1: de la imagen al movimiento." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-20-meta-oakley-gafas-de-sol-camara-y-asistente-todo-en-uno.md
+++ b/_posts/2025-06-20-meta-oakley-gafas-de-sol-camara-y-asistente-todo-en-uno.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Meta Oakley: gafas de sol, cámara y asistente todo en uno."
+date: 2025-06-20 09:00:00 -0400
+description: "Meta y Oakley lanzan unas smart glasses que combinan diseño deportivo con tecnología integrada: cámara, altavoces, micrófono y asistente de IA en un formato que no parece de..."
+image: "https://img.youtube.com/vi/9bJYt_1hZIM/hqdefault.jpg"
+image_alt: "Meta Oakley: gafas de sol, cámara y asistente todo en uno."
+resumen: "Meta y Oakley lanzan unas smart glasses que combinan diseño deportivo con tecnología integrada: cámara, altavoces, micrófono y asistente de IA en un formato que no parece de..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "9bJYt_1hZIM"
+youtube_url: "https://www.youtube.com/watch?v=9bJYt_1hZIM"
+---
+
+Meta y Oakley lanzan unas smart glasses que combinan diseño deportivo con tecnología integrada: cámara, altavoces, micrófono y asistente de IA en un formato que no parece de ciencia ficción. 
+
+
+¿Moda tech o el primer wearable realmente útil para el día a día?
+
+
+ Te contamos todo en este episodio.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/9bJYt_1hZIM" title="Meta Oakley: gafas de sol, cámara y asistente todo en uno." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-23-project-indigo-la-nueva-camara-de-adobe-que-trae-la-fotografia-profesional-al-iphone.md
+++ b/_posts/2025-06-23-project-indigo-la-nueva-camara-de-adobe-que-trae-la-fotografia-profesional-al-iphone.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "Project Indigo: la nueva cámara de Adobe que trae la fotografía profesional al iPhone"
+date: 2025-06-23 09:00:00 -0400
+description: "Adobe lanza Project Indigo, su app de cámara experimental para iPhone que combina fotografía computacional avanzada y controles manuales tipo DSLR."
+image: "https://img.youtube.com/vi/p-SV6ME7mNg/hqdefault.jpg"
+image_alt: "Project Indigo: la nueva cámara de Adobe que trae la fotografía profesional al iPhone"
+resumen: "Adobe lanza Project Indigo, su app de cámara experimental para iPhone que combina fotografía computacional avanzada y controles manuales tipo DSLR."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "p-SV6ME7mNg"
+youtube_url: "https://www.youtube.com/watch?v=p-SV6ME7mNg"
+---
+
+Adobe lanza Project Indigo, su app de cámara experimental para iPhone que combina fotografía computacional avanzada y controles manuales tipo DSLR. 
+
+
+Captura ráfagas de hasta 32 fotogramas, genera imágenes HDR con menos ruido y ofrece salida en JPEG y RAW/DNG, todo sin necesidad de cuenta Adobe.
+
+
+En este episodio analizamos su tecnología, modos Photo y Night, zoom superresolución, edición nativa en Lightroom y su potencial para cambiar la fotografía móvil. 
+
+
+Además, debatimos sobre sus limitaciones actuales como el sobrecalentamiento y qué novedades podría traer en futuras actualizaciones.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/p-SV6ME7mNg" title="Project Indigo: la nueva cámara de Adobe que trae la fotografía profesional al iPhone" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-24-11-ai-elevenlabs-pasa-de-la-voz-a-la-ia.md
+++ b/_posts/2025-06-24-11-ai-elevenlabs-pasa-de-la-voz-a-la-ia.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "11.ai: ElevenLabs pasa de la voz a la iA."
+date: 2025-06-24 09:00:00 -0400
+description: "ElevenLabs lanza 11.ai, su plataforma definitiva de clonación y generación de voz."
+image: "https://img.youtube.com/vi/JlMAfFvvOHw/hqdefault.jpg"
+image_alt: "11.ai: ElevenLabs pasa de la voz a la iA."
+resumen: "ElevenLabs lanza 11.ai, su plataforma definitiva de clonación y generación de voz."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "JlMAfFvvOHw"
+youtube_url: "https://www.youtube.com/watch?v=JlMAfFvvOHw"
+---
+
+ElevenLabs lanza 11.ai, su plataforma definitiva de clonación y generación de voz. 
+
+
+En este episodio exploramos sus nuevas capacidades multimodales, integración con video, mejoras en realismo y sincronización labial, y lo que esto significa para la creación de contenido, el doblaje y la identidad vocal. 
+
+
+¿Estamos ante el fin del doblaje tradicional o el principio de algo aún más inquietante?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/JlMAfFvvOHw" title="11.ai: ElevenLabs pasa de la voz a la iA." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-06-25-meta-quest-3s-xbox-edition-vr-y-consola-en-un-solo-visor.md
+++ b/_posts/2025-06-25-meta-quest-3s-xbox-edition-vr-y-consola-en-un-solo-visor.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Meta Quest 3S Xbox Edition: VR y consola en un solo visor"
+date: 2025-06-25 09:00:00 -0400
+description: "Meta lanza la Quest 3S en edición especial Xbox, combinando realidad virtual con acceso total al ecosistema Xbox Cloud Gaming."
+image: "https://img.youtube.com/vi/Dg5qbsqN3eQ/hqdefault.jpg"
+image_alt: "Meta Quest 3S Xbox Edition: VR y consola en un solo visor"
+resumen: "Meta lanza la Quest 3S en edición especial Xbox, combinando realidad virtual con acceso total al ecosistema Xbox Cloud Gaming."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Dg5qbsqN3eQ"
+youtube_url: "https://www.youtube.com/watch?v=Dg5qbsqN3eQ"
+---
+
+Meta lanza la Quest 3S en edición especial Xbox, combinando realidad virtual con acceso total al ecosistema Xbox Cloud Gaming. 
+
+
+En este episodio analizamos sus especificaciones, precio reducido, compatibilidad con mandos y qué significa este movimiento para el futuro del gaming portátil, sin pantallas… pero con mucho hype.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Dg5qbsqN3eQ" title="Meta Quest 3S Xbox Edition: VR y consola en un solo visor" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-01-cursor-ahora-en-web-y-moviles.md
+++ b/_posts/2025-07-01-cursor-ahora-en-web-y-moviles.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Cursor: Ahora en web y moviles."
+date: 2025-07-01 09:00:00 -0400
+description: "Cursor, el editor de código potenciado por IA, ya no es solo de escritorio."
+image: "https://img.youtube.com/vi/bmdzmUdiKB8/hqdefault.jpg"
+image_alt: "Cursor: Ahora en web y moviles."
+resumen: "Cursor, el editor de código potenciado por IA, ya no es solo de escritorio."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "bmdzmUdiKB8"
+youtube_url: "https://www.youtube.com/watch?v=bmdzmUdiKB8"
+---
+
+Cursor, el editor de código potenciado por IA, ya no es solo de escritorio. 
+
+
+En este episodio hablamos de su llegada a navegadores y dispositivos móviles, sus nuevas funciones colaborativas, compatibilidad con GitHub y por qué cada vez más developers lo consideran el copiloto definitivo para programar desde cualquier lugar.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/bmdzmUdiKB8" title="Cursor: Ahora en web y moviles." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-03-pixelmator-pro-el-photoshop-de-apple-ahora-con-ia.md
+++ b/_posts/2025-07-03-pixelmator-pro-el-photoshop-de-apple-ahora-con-ia.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Pixelmator Pro: el \"Photoshop\" de Apple ahora con IA."
+date: 2025-07-03 09:00:00 -0400
+description: "Apple ha comprado Pixelmator Pro y no es casualidad."
+image: "https://img.youtube.com/vi/Ms8OntCGYyU/hqdefault.jpg"
+image_alt: "Pixelmator Pro: el \"Photoshop\" de Apple ahora con IA."
+resumen: "Apple ha comprado Pixelmator Pro y no es casualidad."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Ms8OntCGYyU"
+youtube_url: "https://www.youtube.com/watch?v=Ms8OntCGYyU"
+---
+
+Apple ha comprado Pixelmator Pro y no es casualidad. 
+
+
+En este episodio analizamos por qué esta app de edición se ha convertido en el “Photoshop” made in Cupertino, sus nuevas funciones con inteligencia artificial y qué significa esta adquisición para el futuro creativo del ecosistema Apple. 
+
+
+¿Se viene una revolución silenciosa en Fotos, Pages o incluso Final Cut?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Ms8OntCGYyU" title="Pixelmator Pro: el &quot;Photoshop&quot; de Apple ahora con IA." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-15-apple-cambia-de-coo.md
+++ b/_posts/2025-07-15-apple-cambia-de-coo.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Apple cambia de COO"
+date: 2025-07-15 09:00:00 -0400
+description: "Apple renueva uno de sus cargos clave: el Chief Operating Officer."
+image: "https://img.youtube.com/vi/kZ38YVxELHI/hqdefault.jpg"
+image_alt: "Apple cambia de COO"
+resumen: "Apple renueva uno de sus cargos clave: el Chief Operating Officer."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "kZ38YVxELHI"
+youtube_url: "https://www.youtube.com/watch?v=kZ38YVxELHI"
+---
+
+Apple renueva uno de sus cargos clave: el Chief Operating Officer. 
+
+
+En este episodio analizamos quién entra, quién sale, y qué implicaciones tiene este movimiento en la estrategia de hardware, fabricación y expansión global. 
+
+
+¿Es solo un ajuste interno o el inicio de una nueva etapa para la compañía?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/kZ38YVxELHI" title="Apple cambia de COO" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-16-grok-4-y-las-waifus-de-elon.md
+++ b/_posts/2025-07-16-grok-4-y-las-waifus-de-elon.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Grok 4 y las waifus de Elon"
+date: 2025-07-16 09:00:00 -0400
+description: "Grok 4 ya está aquí, y no viene solo: el nuevo modelo de IA de xAI incluye “compañeras virtuales” al más puro estilo waifu."
+image: "https://img.youtube.com/vi/7WfR00EsQxY/hqdefault.jpg"
+image_alt: "Grok 4 y las waifus de Elon"
+resumen: "Grok 4 ya está aquí, y no viene solo: el nuevo modelo de IA de xAI incluye “compañeras virtuales” al más puro estilo waifu."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "7WfR00EsQxY"
+youtube_url: "https://www.youtube.com/watch?v=7WfR00EsQxY"
+---
+
+Grok 4 ya está aquí, y no viene solo: el nuevo modelo de IA de xAI incluye “compañeras virtuales” al más puro estilo waifu. 
+
+
+En este episodio analizamos las capacidades reales del modelo, sus diferencias con ChatGPT o Claude, y el debate en torno a las IAs emocionales, la soledad digital y el límite entre lo útil y lo creepy.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/7WfR00EsQxY" title="Grok 4 y las waifus de Elon" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-21-chatgpt-agente-cuando-la-ia-deja-de-esperar-ordenes.md
+++ b/_posts/2025-07-21-chatgpt-agente-cuando-la-ia-deja-de-esperar-ordenes.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "ChatGPT Agente: cuando la IA deja de esperar órdenes"
+date: 2025-07-21 09:00:00 -0400
+description: "OpenAI presenta ChatGPT Agente, una evolución que convierte a ChatGPT en algo más que un asistente: ahora puede actuar, ejecutar tareas y tomar decisiones por sí solo."
+image: "https://img.youtube.com/vi/dAYslvaVPZg/hqdefault.jpg"
+image_alt: "ChatGPT Agente: cuando la IA deja de esperar órdenes"
+resumen: "OpenAI presenta ChatGPT Agente, una evolución que convierte a ChatGPT en algo más que un asistente: ahora puede actuar, ejecutar tareas y tomar decisiones por sí solo."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "dAYslvaVPZg"
+youtube_url: "https://www.youtube.com/watch?v=dAYslvaVPZg"
+---
+
+OpenAI presenta ChatGPT Agente, una evolución que convierte a ChatGPT en algo más que un asistente: ahora puede actuar, ejecutar tareas y tomar decisiones por sí solo. 
+
+
+En este episodio exploramos qué es un agente, cómo funciona esta nueva función, sus usos prácticos… y si estamos un paso más cerca de los asistentes autónomos que soñábamos (o temíamos).
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/dAYslvaVPZg" title="ChatGPT Agente: cuando la IA deja de esperar órdenes" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-07-31-chatgpt-modo-educacion-tu-profesor-con-ia.md
+++ b/_posts/2025-07-31-chatgpt-modo-educacion-tu-profesor-con-ia.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "ChatGPT Modo Educación: tu profesor con IA"
+date: 2025-07-31 09:00:00 -0400
+description: "OpenAI lanza el nuevo Modo Educación de ChatGPT, pensado para estudiantes y profesores."
+image: "https://img.youtube.com/vi/LLSYdEczYuU/hqdefault.jpg"
+image_alt: "ChatGPT Modo Educación: tu profesor con IA"
+resumen: "OpenAI lanza el nuevo Modo Educación de ChatGPT, pensado para estudiantes y profesores."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "LLSYdEczYuU"
+youtube_url: "https://www.youtube.com/watch?v=LLSYdEczYuU"
+---
+
+OpenAI lanza el nuevo Modo Educación de ChatGPT, pensado para estudiantes y profesores. 
+
+
+En este episodio exploramos cómo funciona, qué lo diferencia de la versión estándar y cómo puede cambiar la forma en que se aprende y se enseña. 
+
+
+¿Aliado educativo real o riesgo de atajos mal usados? 
+
+
+Lo analizamos sin rodeos.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/LLSYdEczYuU" title="ChatGPT Modo Educación: tu profesor con IA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-08-07-gpt-oss-el-modelo-de-codigo-abierto-de-openai.md
+++ b/_posts/2025-08-07-gpt-oss-el-modelo-de-codigo-abierto-de-openai.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "GPT-OSS: el modelo de código abierto de OpenAI"
+date: 2025-08-07 09:00:00 -0400
+description: "OpenAI lanza GPT-OSS, su primer modelo de lenguaje open source. En este episodio analizamos qué significa realmente “código abierto” en este contexto, qué nivel de potencia..."
+image: "https://img.youtube.com/vi/sbBR90Es8CI/hqdefault.jpg"
+image_alt: "GPT-OSS: el modelo de código abierto de OpenAI"
+resumen: "OpenAI lanza GPT-OSS, su primer modelo de lenguaje open source. En este episodio analizamos qué significa realmente “código abierto” en este contexto, qué nivel de potencia..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "sbBR90Es8CI"
+youtube_url: "https://www.youtube.com/watch?v=sbBR90Es8CI"
+---
+
+OpenAI lanza GPT-OSS, su primer modelo de lenguaje open source. En este episodio analizamos qué significa realmente “código abierto” en este contexto, qué nivel de potencia ofrece frente a GPT-4 o Mistral, y por qué este movimiento es más político que técnico. 
+
+
+¿Transparencia real o una jugada defensiva frente a la competencia?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/sbBR90Es8CI" title="GPT-OSS: el modelo de código abierto de OpenAI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-08-13-gpt-5-ya-esta-aqui-mas-listo-mas-rapido-mas-humano.md
+++ b/_posts/2025-08-13-gpt-5-ya-esta-aqui-mas-listo-mas-rapido-mas-humano.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "GPT-5 ya está aquí: más listo, más rápido… ¿más humano?"
+date: 2025-08-13 09:00:00 -0400
+description: "OpenAI lanza GPT-5, su modelo más avanzado hasta la fecha."
+image: "https://img.youtube.com/vi/W6fc72g-Gxs/hqdefault.jpg"
+image_alt: "GPT-5 ya está aquí: más listo, más rápido… ¿más humano?"
+resumen: "OpenAI lanza GPT-5, su modelo más avanzado hasta la fecha."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "W6fc72g-Gxs"
+youtube_url: "https://www.youtube.com/watch?v=W6fc72g-Gxs"
+---
+
+OpenAI lanza GPT-5, su modelo más avanzado hasta la fecha. 
+
+
+En este episodio te contamos qué mejoras trae, cómo cambia la experiencia con ChatGPT, qué hay de cierto en su supuesto “razonamiento” y cómo se posiciona frente a Claude 4, Gemini y compañía. 
+
+
+¿Estamos ante una evolución real o solo otro número más?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/W6fc72g-Gxs" title="GPT-5 ya está aquí: más listo, más rápido… ¿más humano?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-02-el-misterio-del-nano-banana.md
+++ b/_posts/2025-09-02-el-misterio-del-nano-banana.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "El Misterio del Nano Banana"
+date: 2025-09-02 09:00:00 -0400
+description: "Google presenta Nano Banana, su nuevo generador de imágenes por IA que promete rapidez, calidad y eficiencia incluso en dispositivos móviles."
+image: "https://img.youtube.com/vi/411or4dh528/hqdefault.jpg"
+image_alt: "El Misterio del Nano Banana"
+resumen: "Google presenta Nano Banana, su nuevo generador de imágenes por IA que promete rapidez, calidad y eficiencia incluso en dispositivos móviles."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "411or4dh528"
+youtube_url: "https://www.youtube.com/watch?v=411or4dh528"
+---
+
+Google presenta Nano Banana, su nuevo generador de imágenes por IA que promete rapidez, calidad y eficiencia incluso en dispositivos móviles.
+
+En este episodio exploramos cómo funciona, qué lo diferencia de modelos como Midjourney o DALL·E, y por qué su extraño nombre no le quita ni un gramo de poder creativo.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/411or4dh528" title="El Misterio del Nano Banana" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-05-hyper-dragon-ball-z-el-juego-por-y-para-fans-de-dragon-ball.md
+++ b/_posts/2025-09-05-hyper-dragon-ball-z-el-juego-por-y-para-fans-de-dragon-ball.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Hyper Dragon Ball Z: el juego por y para fans de Dragon Ball."
+date: 2025-09-05 09:00:00 -0400
+description: "Wicked Ambition es la nueva versión de Hyper Dragon Ball Z, un juego hecho por fans con alma de arcade clásico y combos dignos de un Budokai Tenkaichi."
+image: "https://img.youtube.com/vi/adE6VygcZWI/hqdefault.jpg"
+image_alt: "Hyper Dragon Ball Z: el juego por y para fans de Dragon Ball."
+resumen: "Wicked Ambition es la nueva versión de Hyper Dragon Ball Z, un juego hecho por fans con alma de arcade clásico y combos dignos de un Budokai Tenkaichi."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "adE6VygcZWI"
+youtube_url: "https://www.youtube.com/watch?v=adE6VygcZWI"
+---
+
+Wicked Ambition es la nueva versión de Hyper Dragon Ball Z, un juego hecho por fans con alma de arcade clásico y combos dignos de un Budokai Tenkaichi. 
+
+En este episodio repasamos su desarrollo, novedades, estilo visual retro y por qué este proyecto gratuito es, para muchos, el mejor juego de lucha de Dragon Ball… sin llevar el logo de Bandai.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/adE6VygcZWI" title="Hyper Dragon Ball Z: el juego por y para fans de Dragon Ball." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-16-ios-26-y-liquid-glass-el-iphone-ahora-se-siente-liquido.md
+++ b/_posts/2025-09-16-ios-26-y-liquid-glass-el-iphone-ahora-se-siente-liquido.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "iOS 26 & Liquid Glass: el iPhone ahora se siente líquido"
+date: 2025-09-16 09:00:00 -0400
+description: "Apple presenta iOS 26 junto a Liquid Glass, su nuevo lenguaje de diseño lleno de transparencias dinámicas, profundidad visual y animaciones fluidas. En este episodio exploramos..."
+image: "https://img.youtube.com/vi/cPjrbKPps8I/hqdefault.jpg"
+image_alt: "iOS 26 & Liquid Glass: el iPhone ahora se siente líquido"
+resumen: "Apple presenta iOS 26 junto a Liquid Glass, su nuevo lenguaje de diseño lleno de transparencias dinámicas, profundidad visual y animaciones fluidas. En este episodio exploramos..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "cPjrbKPps8I"
+youtube_url: "https://www.youtube.com/watch?v=cPjrbKPps8I"
+---
+
+Apple presenta iOS 26 junto a Liquid Glass, su nuevo lenguaje de diseño lleno de transparencias dinámicas, profundidad visual y animaciones fluidas. En este episodio exploramos qué cambia en el iPhone, cómo se integra con visionOS y por qué este salto visual podría marcar el inicio de una nueva era estética en todo el ecosistema Apple.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/cPjrbKPps8I" title="iOS 26 &amp; Liquid Glass: el iPhone ahora se siente líquido" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-19-n8n-el-nuevo-rey-de-la-automatizacion.md
+++ b/_posts/2025-09-19-n8n-el-nuevo-rey-de-la-automatizacion.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: "N8N: El nuevo rey de la automatización."
+date: 2025-09-19 09:00:00 -0400
+description: "En este episodio exploramos n8n, la plataforma de automatización que planta cara a Zapier y Make con un enfoque open source, flexible y sin límites de nodos."
+image: "https://img.youtube.com/vi/zNFf4tQOpUY/hqdefault.jpg"
+image_alt: "N8N: El nuevo rey de la automatización."
+resumen: "En este episodio exploramos n8n, la plataforma de automatización que planta cara a Zapier y Make con un enfoque open source, flexible y sin límites de nodos."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "zNFf4tQOpUY"
+youtube_url: "https://www.youtube.com/watch?v=zNFf4tQOpUY"
+---
+
+En este episodio exploramos n8n, la plataforma de automatización que planta cara a Zapier y Make con un enfoque open source, flexible y sin límites de nodos. 
+Hablamos de sus casos de uso, su potencial para crear flujos complejos y por qué se ha convertido en el secreto favorito de los makers.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/zNFf4tQOpUY" title="N8N: El nuevo rey de la automatización." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-22-meta-connect-2025-gafas-ai-y-vision-al-futuro.md
+++ b/_posts/2025-09-22-meta-connect-2025-gafas-ai-y-vision-al-futuro.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Meta Connect 2025: gafas, AI y visión al futuro"
+date: 2025-09-22 09:00:00 -0400
+description: "En este episodio hacemos un recorrido completo por lo más destacado del Meta Connect 2025: desde las nuevas Ray-Ban Display con pantalla integrada y la Meta Neural Band, hasta..."
+image: "https://img.youtube.com/vi/pDc-BRSTqbk/hqdefault.jpg"
+image_alt: "Meta Connect 2025: gafas, AI y visión al futuro"
+resumen: "En este episodio hacemos un recorrido completo por lo más destacado del Meta Connect 2025: desde las nuevas Ray-Ban Display con pantalla integrada y la Meta Neural Band, hasta..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "pDc-BRSTqbk"
+youtube_url: "https://www.youtube.com/watch?v=pDc-BRSTqbk"
+---
+
+En este episodio hacemos un recorrido completo por lo más destacado del Meta Connect 2025: desde las nuevas Ray-Ban Display con pantalla integrada y la Meta Neural Band, hasta las gafas deportivas Oakley Meta Vanguard, mejoras en Horizon OS y novedades para desarrolladores con herramientas para wearables y mundos crecientes. 
+
+Discusión de lo bueno, lo que falló en demo en vivo, precios, fechas de lanzamiento… y qué implican todos estos avances para el camino hacia una computación más inmersiva.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/pDc-BRSTqbk" title="Meta Connect 2025: gafas, AI y visión al futuro" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-29-bevel-health-tu-salud-en-una-sola-app.md
+++ b/_posts/2025-09-29-bevel-health-tu-salud-en-una-sola-app.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Bevel Health: tu salud en una sola app"
+date: 2025-09-29 09:00:00 -0400
+description: "En este episodio exploramos Bevel Health, la aplicación que busca centralizar todos tus datos médicos y de bienestar en un mismo lugar."
+image: "https://img.youtube.com/vi/95Gw35LxPBA/hqdefault.jpg"
+image_alt: "Bevel Health: tu salud en una sola app"
+resumen: "En este episodio exploramos Bevel Health, la aplicación que busca centralizar todos tus datos médicos y de bienestar en un mismo lugar."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "95Gw35LxPBA"
+youtube_url: "https://www.youtube.com/watch?v=95Gw35LxPBA"
+---
+
+En este episodio exploramos Bevel Health, la aplicación que busca centralizar todos tus datos médicos y de bienestar en un mismo lugar. 
+
+Hablamos de cómo funciona, qué la diferencia de otras apps de salud, su integración con Apple Health y por qué podría convertirse en la herramienta clave para llevar un control más claro y completo de tu salud digital.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/95Gw35LxPBA" title="Bevel Health: tu salud en una sola app" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-09-30-time-blocking-la-tecnica-que-organiza-tu-dia-por-bloques.md
+++ b/_posts/2025-09-30-time-blocking-la-tecnica-que-organiza-tu-dia-por-bloques.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Time Blocking: la técnica que organiza tu día por bloques"
+date: 2025-09-30 09:00:00 -0400
+description: "En este episodio hablamos del Time Blocking, una de las técnicas de productividad más efectivas para dejar de improvisar y empezar a planificar."
+image: "https://img.youtube.com/vi/-Ui8h_aBvY8/hqdefault.jpg"
+image_alt: "Time Blocking: la técnica que organiza tu día por bloques"
+resumen: "En este episodio hablamos del Time Blocking, una de las técnicas de productividad más efectivas para dejar de improvisar y empezar a planificar."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "-Ui8h_aBvY8"
+youtube_url: "https://www.youtube.com/watch?v=-Ui8h_aBvY8"
+---
+
+En este episodio hablamos del Time Blocking, una de las técnicas de productividad más efectivas para dejar de improvisar y empezar a planificar. 
+
+Te contamos cómo funciona, cómo aplicarlo con las apps nativas de Apple (Recordatorios y Calendario) y por qué puede ayudarte a ganar claridad, foco y control sobre tu tiempo.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/-Ui8h_aBvY8" title="Time Blocking: la técnica que organiza tu día por bloques" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-01-mixboard-de-google-un-lienzo-visual-con-ia.md
+++ b/_posts/2025-10-01-mixboard-de-google-un-lienzo-visual-con-ia.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Mixboard de Google: un lienzo visual con IA"
+date: 2025-10-01 09:00:00 -0400
+description: "Google lanza Mixboard, una herramienta experimental que reinventa los moodboards con inteligencia artificial."
+image: "https://img.youtube.com/vi/ED0TXOuefVM/hqdefault.jpg"
+image_alt: "Mixboard de Google: un lienzo visual con IA"
+resumen: "Google lanza Mixboard, una herramienta experimental que reinventa los moodboards con inteligencia artificial."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "ED0TXOuefVM"
+youtube_url: "https://www.youtube.com/watch?v=ED0TXOuefVM"
+---
+
+Google lanza Mixboard, una herramienta experimental que reinventa los moodboards con inteligencia artificial. 
+
+https://labs.google.com/mixboard/
+
+En este episodio exploramos cómo funciona: empezar con un prompt de texto, generar imágenes, editar con comandos naturales y mezclar ideas visuales. 
+
+Hablamos de Nano Banana, Gemini, el público al que está dirigido, sus limitaciones actuales y cómo encaja en el ecosistema creativo de Google versus herramientas como Pinterest o Canva.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/ED0TXOuefVM" title="Mixboard de Google: un lienzo visual con IA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-02-chatgpt-pulse-la-ia-que-se-adelanta-a-tus-preguntas.md
+++ b/_posts/2025-10-02-chatgpt-pulse-la-ia-que-se-adelanta-a-tus-preguntas.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "ChatGPT Pulse: la IA que se adelanta a tus preguntas"
+date: 2025-10-02 09:00:00 -0400
+description: "Con ChatGPT Pulse, OpenAI da un paso hacia una IA verdaderamente proactiva: ya no esperas a preguntarle, ahora es ella quien te avisa, resume y anticipa la información que..."
+image: "https://img.youtube.com/vi/iJRr4pgRctE/hqdefault.jpg"
+image_alt: "ChatGPT Pulse: la IA que se adelanta a tus preguntas"
+resumen: "Con ChatGPT Pulse, OpenAI da un paso hacia una IA verdaderamente proactiva: ya no esperas a preguntarle, ahora es ella quien te avisa, resume y anticipa la información que..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "iJRr4pgRctE"
+youtube_url: "https://www.youtube.com/watch?v=iJRr4pgRctE"
+---
+
+Con ChatGPT Pulse, OpenAI da un paso hacia una IA verdaderamente proactiva: ya no esperas a preguntarle, ahora es ella quien te avisa, resume y anticipa la información que necesitas antes de que la busques. 
+
+En este episodio analizamos cómo funciona, qué la diferencia de las búsquedas clásicas, sus posibles usos en productividad y si realmente puede convertirse en tu asistente de información 24/7.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/iJRr4pgRctE" title="ChatGPT Pulse: la IA que se adelanta a tus preguntas" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-03-metroidvania-el-genero-que-nacio-de-dos-leyendas.md
+++ b/_posts/2025-10-03-metroidvania-el-genero-que-nacio-de-dos-leyendas.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Metroidvania: el género que nació de dos leyendas"
+date: 2025-10-03 09:00:00 -0400
+description: "En este episodio exploramos el origen y la evolución del término Metroidvania, ese híbrido entre Metroid y Castlevania que hoy define a un género entero de videojuegos."
+image: "https://img.youtube.com/vi/t6E7PZ8rXWE/hqdefault.jpg"
+image_alt: "Metroidvania: el género que nació de dos leyendas"
+resumen: "En este episodio exploramos el origen y la evolución del término Metroidvania, ese híbrido entre Metroid y Castlevania que hoy define a un género entero de videojuegos."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "t6E7PZ8rXWE"
+youtube_url: "https://www.youtube.com/watch?v=t6E7PZ8rXWE"
+---
+
+En este episodio exploramos el origen y la evolución del término Metroidvania, ese híbrido entre Metroid y Castlevania que hoy define a un género entero de videojuegos. 
+
+Hablamos de sus mecánicas clave —exploración no lineal, progresión por habilidades, backtracking inteligente—, repasamos títulos clásicos y modernos que marcaron su camino, y analizamos por qué sigue siendo uno de los estilos más adictivos y respetados del gaming.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/t6E7PZ8rXWE" title="Metroidvania: el género que nació de dos leyendas" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-04-el-universo-absolute-de-dc.md
+++ b/_posts/2025-10-04-el-universo-absolute-de-dc.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "El Universo Absolute de DC"
+date: 2025-10-04 09:00:00 -0400
+description: "DC Comics sacude su universo con la nueva línea Absolute, un relanzamiento que reinventa a sus héroes más icónicos desde un nuevo punto de partida."
+image: "https://img.youtube.com/vi/9MIM9dZpNOo/hqdefault.jpg"
+image_alt: "El Universo Absolute de DC"
+resumen: "DC Comics sacude su universo con la nueva línea Absolute, un relanzamiento que reinventa a sus héroes más icónicos desde un nuevo punto de partida."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "9MIM9dZpNOo"
+youtube_url: "https://www.youtube.com/watch?v=9MIM9dZpNOo"
+---
+
+DC Comics sacude su universo con la nueva línea Absolute, un relanzamiento que reinventa a sus héroes más icónicos desde un nuevo punto de partida. 
+
+En este episodio repasamos qué propone esta iniciativa, cómo se diferencia de reinicios anteriores y qué podemos esperar de las nuevas versiones de Superman, Batman y Wonder Woman que marcarán la próxima etapa del cómic mainstream.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/9MIM9dZpNOo" title="El Universo Absolute de DC" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-05-perplexity-el-motor-de-respuestas-con-ia.md
+++ b/_posts/2025-10-05-perplexity-el-motor-de-respuestas-con-ia.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "Perplexity: El Motor de Respuestas con IA"
+date: 2025-10-05 09:00:00 -0400
+description: "En este episodio hablamos de Perplexity, el buscador potenciado por inteligencia artificial que está cambiando cómo encontramos y entendemos la información."
+image: "https://img.youtube.com/vi/A4qAnVM64N8/hqdefault.jpg"
+image_alt: "Perplexity: El Motor de Respuestas con IA"
+resumen: "En este episodio hablamos de Perplexity, el buscador potenciado por inteligencia artificial que está cambiando cómo encontramos y entendemos la información."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "A4qAnVM64N8"
+youtube_url: "https://www.youtube.com/watch?v=A4qAnVM64N8"
+---
+
+En este episodio hablamos de Perplexity, el buscador potenciado por inteligencia artificial que está cambiando cómo encontramos y entendemos la información. 
+
+
+Comentamos sus funciones clave —como elegir el modelo de IA que quieres usar, generar imágenes o citar fuentes— y lo comparamos con alternativas como ChatGPT, Claude y Grok. 
+¿Es realmente el futuro de las búsquedas o solo hype del momento?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/A4qAnVM64N8" title="Perplexity: El Motor de Respuestas con IA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-06-taquilla-vs-critica-que-pesa-mas-en-el-cine-de-2025.md
+++ b/_posts/2025-10-06-taquilla-vs-critica-que-pesa-mas-en-el-cine-de-2025.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Taquilla vs Crítica: ¿qué pesa más en el cine de 2025?"
+date: 2025-10-06 09:00:00 -0400
+description: "En este episodio analizamos la eterna batalla entre la taquilla y la crítica en el mundo del cine, con ejemplos recientes de 2025."
+image: "https://img.youtube.com/vi/CNcO9cuziVE/hqdefault.jpg"
+image_alt: "Taquilla vs Crítica: ¿qué pesa más en el cine de 2025?"
+resumen: "En este episodio analizamos la eterna batalla entre la taquilla y la crítica en el mundo del cine, con ejemplos recientes de 2025."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "CNcO9cuziVE"
+youtube_url: "https://www.youtube.com/watch?v=CNcO9cuziVE"
+---
+
+En este episodio analizamos la eterna batalla entre la taquilla y la crítica en el mundo del cine, con ejemplos recientes de 2025. 
+
+¿Qué significa realmente el éxito hoy en día? 
+
+Hablamos de películas que arrasan en números pero no convencen a la crítica, y de joyas aplaudidas por expertos que fracasan en salas. 
+
+Además, reflexionamos sobre el papel del streaming, el marketing y la comunidad online en este choque de percepciones.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/CNcO9cuziVE" title="Taquilla vs Crítica: ¿qué pesa más en el cine de 2025?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-08-chatgpt-instant-checkout-que-la-ia-compre-por-ti.md
+++ b/_posts/2025-10-08-chatgpt-instant-checkout-que-la-ia-compre-por-ti.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "ChatGPT Instant Checkout: Que la IA compre por ti"
+date: 2025-10-08 09:00:00 -0400
+description: "OpenAI presenta ChatGPT Instant Checkout, una función que convierte la conversación en tienda: pides algo, la IA lo encuentra y lo compras en segundos, sin salir del chat."
+image: "https://img.youtube.com/vi/oNyvljHmpGk/hqdefault.jpg"
+image_alt: "ChatGPT Instant Checkout: Que la IA compre por ti"
+resumen: "OpenAI presenta ChatGPT Instant Checkout, una función que convierte la conversación en tienda: pides algo, la IA lo encuentra y lo compras en segundos, sin salir del chat."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "oNyvljHmpGk"
+youtube_url: "https://www.youtube.com/watch?v=oNyvljHmpGk"
+---
+
+OpenAI presenta ChatGPT Instant Checkout, una función que convierte la conversación en tienda: pides algo, la IA lo encuentra y lo compras en segundos, sin salir del chat. 
+
+En este episodio analizamos cómo funciona, qué impacto puede tener en el e-commerce, los riesgos de privacidad y si realmente estamos listos para dejar que una IA se convierta en nuestro carrito de compras automático.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/oNyvljHmpGk" title="ChatGPT Instant Checkout: Que la IA compre por ti" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-08-sora-2-la-nueva-era-del-video-generado-por-ia.md
+++ b/_posts/2025-10-08-sora-2-la-nueva-era-del-video-generado-por-ia.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "SORA 2: La nueva era del video generado por IA"
+date: 2025-10-08 09:00:00 -0400
+description: "En este episodio hablamos del lanzamiento de SORA 2, la evolución del modelo de OpenAI para generación de video."
+image: "https://img.youtube.com/vi/Jt1xd1R_fW8/hqdefault.jpg"
+image_alt: "SORA 2: La nueva era del video generado por IA"
+resumen: "En este episodio hablamos del lanzamiento de SORA 2, la evolución del modelo de OpenAI para generación de video."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Jt1xd1R_fW8"
+youtube_url: "https://www.youtube.com/watch?v=Jt1xd1R_fW8"
+---
+
+En este episodio hablamos del lanzamiento de SORA 2, la evolución del modelo de OpenAI para generación de video. 
+
+Analizamos sus mejoras frente a la primera versión, los avances en realismo, edición y control creativo, y qué significa para el futuro del cine, la animación y la creación de contenido. 
+
+¿Estamos más cerca de producir películas enteras desde un prompt?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Jt1xd1R_fW8" title="SORA 2: La nueva era del video generado por IA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-10-protocolo-mcp-el-idioma-secreto-entre-las-ias.md
+++ b/_posts/2025-10-10-protocolo-mcp-el-idioma-secreto-entre-las-ias.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Protocolo MCP: el idioma secreto entre las IAs"
+date: 2025-10-10 09:00:00 -0400
+description: "En este episodio hablamos del protocolo MCP (Model Context Protocol), el nuevo estándar que permite que distintas inteligencias artificiales y aplicaciones se comuniquen entre sí."
+image: "https://img.youtube.com/vi/f0wNO60Slb4/hqdefault.jpg"
+image_alt: "Protocolo MCP: el idioma secreto entre las IAs"
+resumen: "En este episodio hablamos del protocolo MCP (Model Context Protocol), el nuevo estándar que permite que distintas inteligencias artificiales y aplicaciones se comuniquen entre sí."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "f0wNO60Slb4"
+youtube_url: "https://www.youtube.com/watch?v=f0wNO60Slb4"
+---
+
+En este episodio hablamos del protocolo MCP (Model Context Protocol), el nuevo estándar que permite que distintas inteligencias artificiales y aplicaciones se comuniquen entre sí. 
+
+Explicamos cómo funciona, por qué es clave para la interoperabilidad del ecosistema de IA y qué implicaciones tiene para el futuro: desde agentes conectados hasta apps que se entienden sin intervención humana.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/f0wNO60Slb4" title="Protocolo MCP: el idioma secreto entre las IAs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-11-ia-local-en-tu-iphone-sin-nube-sin-esperas-toda-tuya.md
+++ b/_posts/2025-10-11-ia-local-en-tu-iphone-sin-nube-sin-esperas-toda-tuya.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "IA Local en tu iPhone: sin nube, sin esperas, toda tuya"
+date: 2025-10-11 09:00:00 -0400
+description: "La inteligencia artificial ya no vive solo en servidores gigantes: ahora puede correr directamente en tu iPhone."
+image: "https://img.youtube.com/vi/2iCbdXEZVT0/hqdefault.jpg"
+image_alt: "IA Local en tu iPhone: sin nube, sin esperas, toda tuya"
+resumen: "La inteligencia artificial ya no vive solo en servidores gigantes: ahora puede correr directamente en tu iPhone."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "2iCbdXEZVT0"
+youtube_url: "https://www.youtube.com/watch?v=2iCbdXEZVT0"
+---
+
+La inteligencia artificial ya no vive solo en servidores gigantes: ahora puede correr directamente en tu iPhone. 
+
+En este episodio hablamos de cómo funcionan los modelos en local, qué ventajas tienen frente a la nube, sus límites actuales y qué significa para privacidad, velocidad y el futuro de las apps móviles.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/2iCbdXEZVT0" title="IA Local en tu iPhone: sin nube, sin esperas, toda tuya" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-12-pebble-esta-de-vuelta-el-smartwatch-de-tinta-electronica.md
+++ b/_posts/2025-10-12-pebble-esta-de-vuelta-el-smartwatch-de-tinta-electronica.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Pebble está de vuelta: el smartwatch de tinta electronica"
+date: 2025-10-12 09:00:00 -0400
+description: "Pebble regresa con una nueva propuesta que apuesta por lo esencial: notificaciones, batería para días y cero distracciones."
+image: "https://img.youtube.com/vi/mYQxx693Nsg/hqdefault.jpg"
+image_alt: "Pebble está de vuelta: el smartwatch de tinta electronica"
+resumen: "Pebble regresa con una nueva propuesta que apuesta por lo esencial: notificaciones, batería para días y cero distracciones."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "mYQxx693Nsg"
+youtube_url: "https://www.youtube.com/watch?v=mYQxx693Nsg"
+---
+
+Pebble regresa con una nueva propuesta que apuesta por lo esencial: notificaciones, batería para días y cero distracciones. 
+
+En este episodio repasamos la historia del mítico reloj que se adelantó a su tiempo, analizamos su nuevo enfoque y debatimos si en plena era de la hiperconectividad… menos es más.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/mYQxx693Nsg" title="Pebble está de vuelta: el smartwatch de tinta electronica" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-13-gametrack-la-app-definitiva-para-los-gamers-organizados.md
+++ b/_posts/2025-10-13-gametrack-la-app-definitiva-para-los-gamers-organizados.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "GameTrack: la app definitiva para los gamers organizados"
+date: 2025-10-13 09:00:00 -0400
+description: "Si eres de los que acumula juegos sin control y olvida por qué empezó uno u otro… necesitas GameTrack."
+image: "https://img.youtube.com/vi/1sJWiTQ2awM/hqdefault.jpg"
+image_alt: "GameTrack: la app definitiva para los gamers organizados"
+resumen: "Si eres de los que acumula juegos sin control y olvida por qué empezó uno u otro… necesitas GameTrack."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "1sJWiTQ2awM"
+youtube_url: "https://www.youtube.com/watch?v=1sJWiTQ2awM"
+---
+
+Si eres de los que acumula juegos sin control y olvida por qué empezó uno u otro… necesitas GameTrack. 
+
+En este episodio analizamos esta app que te permite seguir tu biblioteca, marcar tus progresos y planear a qué jugar después. 
+
+Minimalista, útil y perfecta para frikis del backlog.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/1sJWiTQ2awM" title="GameTrack: la app definitiva para los gamers organizados" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-14-la-matriz-de-eisenhower.md
+++ b/_posts/2025-10-14-la-matriz-de-eisenhower.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "La Matriz de Eisenhower"
+date: 2025-10-14 09:00:00 -0400
+description: "En este episodio exploramos la Matriz de Eisenhower, una de las herramientas de productividad más simples y poderosas jamás creadas."
+image: "https://img.youtube.com/vi/dO-Kd_Rm0IU/hqdefault.jpg"
+image_alt: "La Matriz de Eisenhower"
+resumen: "En este episodio exploramos la Matriz de Eisenhower, una de las herramientas de productividad más simples y poderosas jamás creadas."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "dO-Kd_Rm0IU"
+youtube_url: "https://www.youtube.com/watch?v=dO-Kd_Rm0IU"
+---
+
+En este episodio exploramos la Matriz de Eisenhower, una de las herramientas de productividad más simples y poderosas jamás creadas. 
+
+Te explicamos cómo usarla para distinguir entre lo urgente y lo importante, tomar mejores decisiones y recuperar el control de tu tiempo. 
+
+Porque no todo lo que requiere tu atención merece tu energía.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/dO-Kd_Rm0IU" title="La Matriz de Eisenhower" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-16-seguridad-en-la-era-de-la-ia.md
+++ b/_posts/2025-10-16-seguridad-en-la-era-de-la-ia.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Seguridad en la era de la IA"
+date: 2025-10-16 09:00:00 -0400
+description: "En este video exploramos cómo la inteligencia artificial está transformando la seguridad digital y por qué la alianza entre Perplexity y 1Password marca un antes y un después..."
+image: "https://img.youtube.com/vi/Bl25vgy3fMc/hqdefault.jpg"
+image_alt: "Seguridad en la era de la IA"
+resumen: "En este video exploramos cómo la inteligencia artificial está transformando la seguridad digital y por qué la alianza entre Perplexity y 1Password marca un antes y un después..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "Bl25vgy3fMc"
+youtube_url: "https://www.youtube.com/watch?v=Bl25vgy3fMc"
+---
+
+En este video exploramos cómo la inteligencia artificial está transformando la seguridad digital y por qué la alianza entre Perplexity y 1Password marca un antes y un después en la protección de tus credenciales online. 
+
+¿Cómo pueden las nuevas amenazas potenciadas por IA vulnerar contraseñas y qué rol cumple el navegador Comet con 1Password para fortalecer nuestra seguridad? 
+
+Descubre las claves de esta colaboración, las funcionalidades innovadoras que protegen tu información y cómo anticipar el futuro de la navegación segura. 
+
+¡No te lo pierdas!
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/Bl25vgy3fMc" title="Seguridad en la era de la IA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-17-por-que-los-astronautas-llevaban-armas-al-espacio-la-increible-historia-de-la-tp-82.md
+++ b/_posts/2025-10-17-por-que-los-astronautas-llevaban-armas-al-espacio-la-increible-historia-de-la-tp-82.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "¿Por qué los Astronautas llevaban armas al Espacio? La increíble historia de la TP-82"
+date: 2025-10-17 09:00:00 -0400
+description: "¿Sabías que los astronautas y cosmonautas llevaban armas de fuego en sus misiones espaciales?"
+image: "https://img.youtube.com/vi/3PgvQjsnhqY/hqdefault.jpg"
+image_alt: "¿Por qué los Astronautas llevaban armas al Espacio? La increíble historia de la TP-82"
+resumen: "¿Sabías que los astronautas y cosmonautas llevaban armas de fuego en sus misiones espaciales?"
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "3PgvQjsnhqY"
+youtube_url: "https://www.youtube.com/watch?v=3PgvQjsnhqY"
+---
+
+¿Sabías que los astronautas y cosmonautas llevaban armas de fuego en sus misiones espaciales? 
+
+En este capítulo te cuento la sorprendente y poco conocida historia detrás de la famosa pistola TP-82, diseñada especialmente para los viajes al espacio. 
+
+Descubre qué incidente obligó a los cosmonautas soviéticos a equiparse con armas, para qué servían realmente en sus kits de supervivencia y por qué la exploración espacial requería estar preparado para enfrentar osos, lobos y otros peligros… ¡al volver a la Tierra! 
+
+Te explico las curiosidades de la carrera espacial, las diferencias entre los programas ruso y norteamericano, y cómo esta peculiar medida de seguridad marcó toda una era.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/3PgvQjsnhqY" title="¿Por qué los Astronautas llevaban armas al Espacio? La increíble historia de la TP-82" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-21-mejores-apps-de-gestion-de-proyectos-en-2025.md
+++ b/_posts/2025-10-21-mejores-apps-de-gestion-de-proyectos-en-2025.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Mejores apps de gestión de proyectos en 2025."
+date: 2025-10-21 09:00:00 -0400
+description: "¿Buscas la mejor app para organizar tus proyectos personales o colaborar en equipo?"
+image: "https://img.youtube.com/vi/MrLYScZ0_OU/hqdefault.jpg"
+image_alt: "Mejores apps de gestión de proyectos en 2025."
+resumen: "¿Buscas la mejor app para organizar tus proyectos personales o colaborar en equipo?"
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "MrLYScZ0_OU"
+youtube_url: "https://www.youtube.com/watch?v=MrLYScZ0_OU"
+---
+
+¿Buscas la mejor app para organizar tus proyectos personales o colaborar en equipo? 
+
+En este video te presento una comparativa práctica y a fondo entre Notion, Todoist, ClickUp y varias alternativas open source como Plane, OpenProject, Focalboard, Vikunja y Taiga. 
+
+Analizo sus ventajas, desventajas, funcionalidades destacadas y casos de uso ideales para que elijas la plataforma que más se adapta a tus necesidades, ya seas freelancer, estudiante, parte de un equipo pequeño o una empresa. 
+
+Si te apasiona la productividad, la gestión de proyectos y quieres conocer herramientas potentes, flexibles y gratuitas, este video es para ti.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/MrLYScZ0_OU" title="Mejores apps de gestión de proyectos en 2025." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-22-atlas-el-navegador-con-chatgpt-de-openai-revolucion-o-hype.md
+++ b/_posts/2025-10-22-atlas-el-navegador-con-chatgpt-de-openai-revolucion-o-hype.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "ATLAS, el navegador con ChatGPT de OpenAI: ¿Revolución o hype? 🚀"
+date: 2025-10-22 09:00:00 -0400
+description: "¡OpenAI lo ha vuelto a hacer!"
+image: "https://img.youtube.com/vi/tClhfmNVc5Q/hqdefault.jpg"
+image_alt: "ATLAS, el navegador con ChatGPT de OpenAI: ¿Revolución o hype? 🚀"
+resumen: "¡OpenAI lo ha vuelto a hacer!"
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "tClhfmNVc5Q"
+youtube_url: "https://www.youtube.com/watch?v=tClhfmNVc5Q"
+---
+
+¡OpenAI lo ha vuelto a hacer! 
+
+En este video te cuento todo sobre el lanzamiento de Atlas, el nuevo navegador inteligente con integración nativa de ChatGPT. 
+
+Descubre cómo funciona su modo agente, qué ventajas ofrece frente a Google Chrome y otros navegadores tradicionales, y cuáles son sus principales características de IA que prometen transformar nuestra forma de navegar y buscar información en Internet. 
+
+¿Estás listo para una nueva experiencia web conversacional?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/tClhfmNVc5Q" title="ATLAS, el navegador con ChatGPT de OpenAI: ¿Revolución o hype? 🚀" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-23-apple-revoluciona-la-f1.md
+++ b/_posts/2025-10-23-apple-revoluciona-la-f1.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: "Apple revoluciona la F1"
+date: 2025-10-23 09:00:00 -0400
+description: "¡Apple lo hace de nuevo!"
+image: "https://img.youtube.com/vi/tw_ITwjdLoA/hqdefault.jpg"
+image_alt: "Apple revoluciona la F1"
+resumen: "¡Apple lo hace de nuevo!"
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "tw_ITwjdLoA"
+youtube_url: "https://www.youtube.com/watch?v=tw_ITwjdLoA"
+---
+
+¡Apple lo hace de nuevo! 
+La gigante tecnológica acaba de adquirir los derechos exclusivos de retransmisión de la Fórmula 1 en Estados Unidos en un acuerdo histórico de $750 millones, desplazando a ESPN y revolucionando cómo veremos la máxima categoría del automovilismo. 
+
+Te explico los detalles del acuerdo, cómo afectará a los fans y qué novedades traerá para los usuarios de Apple TV, incluyendo acceso a F1 TV Premium y la integración total con el ecosistema Apple. 
+
+Además, analizamos las ventajas, controversias y el potencial impacto en la cultura deportiva estadounidense. ¿Será este el futuro del deporte en vivo?
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/tw_ITwjdLoA" title="Apple revoluciona la F1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-24-optimus-el-robot-de-elon-musk.md
+++ b/_posts/2025-10-24-optimus-el-robot-de-elon-musk.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title: "Optimus: El robot de Elon Musk"
+date: 2025-10-24 09:00:00 -0400
+description: "En este video exploramos al detalle a Optimus, el robot humanoide desarrollado por Tesla bajo la visión de Elon Musk."
+image: "https://img.youtube.com/vi/nyMhyDjhCz8/hqdefault.jpg"
+image_alt: "Optimus: El robot de Elon Musk"
+resumen: "En este video exploramos al detalle a Optimus, el robot humanoide desarrollado por Tesla bajo la visión de Elon Musk."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "nyMhyDjhCz8"
+youtube_url: "https://www.youtube.com/watch?v=nyMhyDjhCz8"
+---
+
+En este video exploramos al detalle a Optimus, el robot humanoide desarrollado por Tesla bajo la visión de Elon Musk. 
+
+Conoce sus características técnicas, avances en inteligencia artificial y capacidades reales en la industria y el hogar. 
+Analizaremos los retos del proyecto, la influencia de Optimus en el futuro del trabajo y cómo podría transformar nuestra vida cotidiana. 
+
+Además, compartimos opiniones y reviews tanto en texto como en video, y te contamos por qué este podría convertirse en el producto más relevante de Tesla.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/nyMhyDjhCz8" title="Optimus: El robot de Elon Musk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-28-que-es-airtable.md
+++ b/_posts/2025-10-28-que-es-airtable.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "¿Qué es Airtable?"
+date: 2025-10-28 09:00:00 -0400
+description: "En este video descubrirás qué es Airtable, una herramienta versátil que combina lo mejor de las hojas de cálculo y las bases de datos."
+image: "https://img.youtube.com/vi/wMVg7xXSuYQ/hqdefault.jpg"
+image_alt: "¿Qué es Airtable?"
+resumen: "En este video descubrirás qué es Airtable, una herramienta versátil que combina lo mejor de las hojas de cálculo y las bases de datos."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "wMVg7xXSuYQ"
+youtube_url: "https://www.youtube.com/watch?v=wMVg7xXSuYQ"
+---
+
+En este video descubrirás qué es Airtable, una herramienta versátil que combina lo mejor de las hojas de cálculo y las bases de datos. 
+
+Te mostraré cómo funciona, sus principales características, ventajas y casos de uso para organizar tus proyectos, equipos y tareas. 
+
+¡Aprende a sacar el máximo provecho de Airtable y empieza a gestionar tu trabajo como un profesional! 
+
+Además, revisamos opiniones y te doy consejos para principiantes.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/wMVg7xXSuYQ" title="¿Qué es Airtable?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/_posts/2025-10-29-modelos-de-ia-privados-vs-open-source.md
+++ b/_posts/2025-10-29-modelos-de-ia-privados-vs-open-source.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "Modelos de IA: Privados vs Open Source"
+date: 2025-10-29 09:00:00 -0400
+description: "En el mundo de la inteligencia artificial se libra una guerra silenciosa: los modelos cerrados y privados, controlados por gigantes como OpenAI, Google o Anthropic, contra los..."
+image: "https://img.youtube.com/vi/XqOrlzvdriY/hqdefault.jpg"
+image_alt: "Modelos de IA: Privados vs Open Source"
+resumen: "En el mundo de la inteligencia artificial se libra una guerra silenciosa: los modelos cerrados y privados, controlados por gigantes como OpenAI, Google o Anthropic, contra los..."
+categories: [youtube]
+tags: [youtube]
+source: "youtube"
+youtube_id: "XqOrlzvdriY"
+youtube_url: "https://www.youtube.com/watch?v=XqOrlzvdriY"
+---
+
+En el mundo de la inteligencia artificial se libra una guerra silenciosa: los modelos cerrados y privados, controlados por gigantes como OpenAI, Google o Anthropic, contra los modelos open source, cada vez más potentes y accesibles. 
+
+En este episodio analizamos sus diferencias, ventajas, riesgos y lo que este choque significa para el futuro de la innovación.
+
+## Vídeo original
+
+<iframe class="youtube-embed" width="560" height="315" src="https://www.youtube.com/embed/XqOrlzvdriY" title="Modelos de IA: Privados vs Open Source" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
## What changed

Added 128 generated blog posts for YouTube playlist videos that did not already have corresponding posts. Each post uses the YouTube thumbnail as the featured image, the video description as the post body, and embeds the original video at the end.

## Why

This fills the missing blog coverage for the CULTURAFREAK YouTube playlist while preserving the existing post convention for `youtube_id`, `youtube_url`, remote thumbnails, and iframe embeds.

## Validation

- Compared playlist IDs against existing `_posts` entries and confirmed `missing_from_playlist=0`.
- Checked all YouTube posts have unique `youtube_id` values.
- Parsed all post front matter with Ruby YAML successfully.
- Confirmed YouTube posts include matching thumbnail and iframe URLs.

Note: full Jekyll build could not be run locally because this checkout has no `Gemfile` and `jekyll` is not installed in PATH.